### PR TITLE
chore(workflow): Ignore publish docker image on forked branches/repositories

### DIFF
--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    if: github.actor != 'dependabot[bot]'
+    if: github.repository == 'JellyfishSDK/jellyfish' && github.actor != 'dependabot[bot]'
     name: Publish
     runs-on: ubuntu-latest
     strategy:
@@ -61,7 +61,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/jellyfishsdk/jellyfish:buildcache,mode=max
 
   report:
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    if: github.repository == 'JellyfishSDK/jellyfish' && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     name: Report
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Due to forked permission limitations, we shouldn't run the "publish docker image" on a forked branch as it will fail due to 403 error. To avoid this we specify the original repository as the only repository to trigger actions related to docker image publishing.

See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1602
