### PR TITLE
chore(whale-api): remove `-disablewallet=1` on `apps/whale-api/docker-compose.yml`

### DIFF
--- a/apps/whale-api/docker-compose.yml
+++ b/apps/whale-api/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       -rpcpassword=whale-rpcpassword
       -rpcworkqueue=512
       -masternode_operator=mswsMVsyGMj1FzDMbbxw2QW3KvQAv2FKiy
-      -disablewallet=1
       -regtest=1
       -jellyfish_regtest=1
       -txnotokens=0


### PR DESCRIPTION
#### What this PR does / why we need it:

Since `docker-compose.yml` is used as an example for developers on how to set up their "ocean". We should remove 
`-disablewallet=1` to prevent confusion.

