### PR TITLE
chore(jellyfish-api-core): add more tests for poolSwap maxPrice and dex fees

### DIFF
--- a/apps/legacy-api/__tests__/controllers/StatsController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/StatsController.test.ts
@@ -44,7 +44,8 @@ describe('StatsController', () => {
         emissionburn: expect.any(String),
         dfip2203: expect.arrayContaining(
           [expect.stringMatching(/\d+\.?\d+@\w+/)] // ['123@BTC', '10.8@DFI', ...]
-        )
+        ),
+        dfip2206f: expect.any(Array)
       },
 
       timeStamp: expect.any(Number),

--- a/packages/jellyfish-api-core/__tests__/category/poolpair/poolswap.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/poolpair/poolswap.test.ts
@@ -167,7 +167,7 @@ describe('poolSwap', () => {
     })
     await container.generate(1)
 
-    const inputDFIAmount = new BigNumber(1);
+    const inputDFIAmount = new BigNumber(1)
     const metadata = {
       from: address,
       tokenFrom: 'DFI',

--- a/packages/jellyfish-api-core/__tests__/category/poolpair/poolswap.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/poolpair/poolswap.test.ts
@@ -167,14 +167,22 @@ describe('poolSwap', () => {
     })
     await container.generate(1)
 
+    const inputDFIAmount = new BigNumber(1);
     const metadata = {
       from: address,
       tokenFrom: 'DFI',
-      amountFrom: 1,
+      amountFrom: inputDFIAmount.toNumber(),
       to: address,
       tokenTo: 'SLIP',
       maxPrice: 1.5
     }
+
+    // manual calculations and verify
+    const inputDFIAfterFeeIn = inputDFIAmount.minus(inputDFIAmount.multipliedBy(0.05))
+    // (SLIP 1000: DFI 1000)
+    const ammSwappedAmountInSLIP = new BigNumber(1000).minus(new BigNumber(1000 * 1000).dividedBy(new BigNumber(inputDFIAfterFeeIn).plus(1000))).multipliedBy(100000000).minus(1).dividedBy(100000000).decimalPlaces(8, BigNumber.ROUND_CEIL)
+    const finalAmountAfterFeeOut = ammSwappedAmountInSLIP.minus(ammSwappedAmountInSLIP.multipliedBy(0.3))
+    expect(inputDFIAmount.dividedBy(finalAmountAfterFeeOut).gt(1.5)).toBeTruthy()
 
     await expect(client.poolpair.poolSwap(metadata))
       .rejects.toThrow('Price is higher than indicated.')

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_dex_compositeswap_maxprice.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_dex_compositeswap_maxprice.test.ts
@@ -66,7 +66,7 @@ afterAll(async () => {
   await container.stop()
 })
 
-it('should compositeSwap with maxPrice accounting for commission and dexFees', async () => {
+it('should not compositeSwap with maxPrice accounting for commission and dexFees', async () => {
   await providers.randomizeEllipticPair()
   await container.waitForWalletBalanceGTE(1)
 
@@ -98,7 +98,7 @@ it('should compositeSwap with maxPrice accounting for commission and dexFees', a
       fromAmount: new BigNumber('1'),
       toScript: script,
       toTokenId: pairs.CAT.tokenId,
-      maxPrice: new BigNumber('1.005')
+      maxPrice: new BigNumber('1.2')
     },
     pools: [
       { id: pairs.PIG.poolId },

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_dex_compositeswap_maxprice.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_dex_compositeswap_maxprice.test.ts
@@ -91,7 +91,7 @@ it('should not compositeSwap with maxPrice accounting for commission and dexFees
   // Fund 10 DFI UTXO, allow provider able to collect 1
   await fundEllipticPair(container, providers.ellipticPair, 10)
 
-   const inputPIGAmount = new BigNumber(1);
+  const inputPIGAmount = new BigNumber(1)
   const txn = await builder.dex.compositeSwap({
     poolSwap: {
       fromScript: script,
@@ -117,7 +117,7 @@ it('should not compositeSwap with maxPrice accounting for commission and dexFees
   // DFI -> CAT
   const inputDFIAfterFeeIn = intermediateSwappedAmountAfterFeeOut.minus(intermediateSwappedAmountAfterFeeOut.multipliedBy(0.15))
   const ammSwappedAmountInCAT = new BigNumber(1000).minus(new BigNumber(1000 * 1000).dividedBy(new BigNumber(inputDFIAfterFeeIn).plus(1000))).multipliedBy(100000000).minus(1).dividedBy(100000000).decimalPlaces(8, BigNumber.ROUND_CEIL)
-  const finalSwappedAmountAfterFeeOut = ammSwappedAmountInCAT;
+  const finalSwappedAmountAfterFeeOut = ammSwappedAmountInCAT
   expect(inputPIGAmount.dividedBy(finalSwappedAmountAfterFeeOut).gt(1.2)).toBeTruthy()
 
   const promise = sendTransaction(container, txn)

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_dex_compositeswap_maxprice.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_dex_compositeswap_maxprice.test.ts
@@ -1,0 +1,116 @@
+import BigNumber from 'bignumber.js'
+import { DeFiDRpcError, MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { getProviders, MockProviders } from '../provider.mock'
+import { P2WPKHTransactionBuilder } from '../../src'
+import { fundEllipticPair, sendTransaction } from '../test.utils'
+import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
+import { RegTest } from '@defichain/jellyfish-network'
+import { Testing } from '@defichain/jellyfish-testing'
+
+const container = new MasterNodeRegTestContainer()
+let providers: MockProviders
+let builder: P2WPKHTransactionBuilder
+let jsonRpc: JsonRpcClient
+let testing: Testing
+
+interface Pair {
+  tokenId: number
+  poolId: number
+}
+
+const pairs: Record<string, Pair> = {
+  PIG: { tokenId: Number.NaN, poolId: Number.NaN },
+  CAT: { tokenId: Number.NaN, poolId: Number.NaN },
+  DOG: { tokenId: Number.NaN, poolId: Number.NaN }
+}
+
+beforeAll(async () => {
+  await container.start()
+  await container.waitForWalletCoinbaseMaturity()
+  jsonRpc = new JsonRpcClient(await container.getCachedRpcUrl())
+
+  providers = await getProviders(container)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
+  testing = Testing.create(container)
+
+  // creating DFI-* pool pairs and funding liquidity
+  for (const symbol of Object.keys(pairs)) {
+    await testing.token.create({ symbol })
+    await testing.generate(1)
+
+    const token = await container.call('gettoken', [symbol])
+    pairs[symbol].tokenId = Number.parseInt(Object.keys(token)[0])
+
+    await testing.token.mint({ symbol, amount: 1000000 })
+    await testing.poolpair.create({ tokenA: symbol, tokenB: 'DFI', commission: 0.002 })
+    await testing.generate(1)
+
+    const pool = await container.call('getpoolpair', [`${symbol}-DFI`])
+    pairs[symbol].poolId = Number.parseInt(Object.keys(pool)[0])
+
+    await testing.rpc.masternode.setGov({
+      ATTRIBUTES: {
+        [`v0/poolpairs/${pairs[symbol].poolId}/token_b_fee_pct`]: '0.15',
+        [`v0/poolpairs/${pairs[symbol].poolId}/token_b_fee_direction`]: 'both'
+      }
+    })
+    await container.generate(1)
+  }
+
+  // Prep 1000 DFI Token for testing
+  await testing.token.dfi({ amount: 300000 })
+  await testing.generate(1)
+})
+
+afterAll(async () => {
+  await container.stop()
+})
+
+it('should compositeSwap with maxPrice accounting for commission and dexFees', async () => {
+  await providers.randomizeEllipticPair()
+  await container.waitForWalletBalanceGTE(1)
+
+  await testing.poolpair.add({
+    a: { symbol: 'PIG', amount: 100000 },
+    b: { symbol: 'DFI', amount: 100000 }
+  })
+  await testing.poolpair.add({
+    a: { symbol: 'CAT', amount: 100000 },
+    b: { symbol: 'DFI', amount: 100000 }
+  })
+  await testing.generate(1)
+
+  await providers.setupMocks() // required to move utxos
+
+  const address = await providers.getAddress()
+  const script = await providers.elliptic.script()
+
+  await testing.token.send({ symbol: 'PIG', amount: 1, address })
+  await testing.generate(1)
+
+  // Fund 10 DFI UTXO, allow provider able to collect 1
+  await fundEllipticPair(container, providers.ellipticPair, 10)
+
+  const txn = await builder.dex.compositeSwap({
+    poolSwap: {
+      fromScript: script,
+      fromTokenId: pairs.PIG.tokenId,
+      fromAmount: new BigNumber('1'),
+      toScript: script,
+      toTokenId: pairs.CAT.tokenId,
+      maxPrice: new BigNumber('1.005')
+    },
+    pools: [
+      { id: pairs.PIG.poolId },
+      { id: pairs.CAT.poolId }
+    ]
+  }, script)
+
+  const promise = sendTransaction(container, txn)
+  await expect(promise).rejects.toThrowError(DeFiDRpcError)
+  await expect(promise).rejects.toThrowError('PoolSwapTx: Price is higher than indicated')
+
+  // Ensure your balance is correct
+  const account = await jsonRpc.account.getAccount(address)
+  expect(account).toStrictEqual(['1.00000000@PIG'])
+})


### PR DESCRIPTION
#### What this PR does / why we need it:

Add more tests for poolSwap "maxPrice" when commissions and dex fees and added.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
