### PR TITLE
chore(whale-api): allow model.probe:readiness to be 20 blocks behind

### DIFF
--- a/apps/whale-api/src/module.model/_model.probes.ts
+++ b/apps/whale-api/src/module.model/_model.probes.ts
@@ -58,8 +58,8 @@ export class ModelProbeIndicator extends ProbeIndicator {
       return this.withDead('model', 'synced blocks are undefined', details)
     }
 
-    if (index + 2 <= defid) {
-      return this.withDead('model', 'synced blocks are more than 2 blocks behind', details)
+    if (index + 20 <= defid) {
+      return this.withDead('model', 'synced blocks are more than 20 blocks behind', details)
     }
 
     // index defid can experience rollback, so make sure the condition is only checked if `Model == DeFid`


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Increase `model.probe:readiness` to 20 blocks behind. 

Since blocks can come in chunked, we don't want premature health_check failures. Although this setting can be adjusted on your deployment setup, this makes it more universal for all whale-api users.
