### PR TITLE
fix(workflows): fix release-apps if conditions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,27 +4,27 @@ labels:
   - label: kind/feature
     sync: true
     matcher:
-      title: "^feat\\(.+\\): .+"
+      title: "^feat\\(.+\\)?: .+"
 
   - label: kind/fix
     sync: true
     matcher:
-      title: "^fix\\(.+\\): .+"
+      title: "^fix\\(.+\\)?: .+"
 
   - label: kind/chore
     sync: true
     matcher:
-      title: "^chore\\(.+\\): .+"
+      title: "^chore\\(.+\\)?: .+"
 
   - label: kind/refactor
     sync: true
     matcher:
-      title: "^refactor\\(.+\\): .+"
+      title: "^refactor\\(.+\\)?: .+"
 
   - label: kind/docs
     sync: true
     matcher:
-      title: "^docs\\(.+\\): .+"
+      title: "^docs\\(.+\\)?: .+"
 
   - label: kind/dependencies
     sync: true

--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build:
-    if: github.repository == 'JellyfishSDK/jellyfish' && github.actor != 'dependabot[bot]'
+    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     name: Publish
     runs-on: ubuntu-latest
     strategy:
@@ -61,7 +61,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/jellyfishsdk/jellyfish:buildcache,mode=max
 
   report:
-    if: github.repository == 'JellyfishSDK/jellyfish' && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     name: Report
     runs-on: ubuntu-latest
     needs: build
@@ -80,3 +80,15 @@ jobs:
         with:
           header: release
           message: ${{ steps.report.outputs.result }}
+
+  forked:
+    if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')
+    name: Forked Report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post Report
+        uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443
+        with:
+          header: release
+          message: |
+            Due to forked Pull Request limited permissions, docker build preview for jellyfish/apps cannot be generated for this PR.

--- a/.github/workflows/release-ecr.yml
+++ b/.github/workflows/release-ecr.yml
@@ -13,7 +13,6 @@ env:
 
 jobs:
   build:
-    if: github.actor != 'dependabot[bot]'
     name: Publish
     runs-on: ubuntu-latest
     environment: ECR Release Publishing

--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -182,6 +182,7 @@
       <w>mediantime</w>
       <w>mempool</w>
       <w>merkleroot</w>
+      <w>micnncim</w>
       <w>mincolratio</w>
       <w>mintable</w>
       <w>mintedblocks</w>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Fix the "if" conditions for the GHCR Pull Request workflow; the if condition needs to check if `head != base`. 

Also added more liberal `.github/labeler.yml` "Semantic PR" scopes