### PR TITLE
feat(whale-api): add name on poolpairs api response

### DIFF
--- a/apps/whale-api/src/module.api/poolpair.controller.e2e.ts
+++ b/apps/whale-api/src/module.api/poolpair.controller.e2e.ts
@@ -372,11 +372,13 @@ describe('get best path', () => {
     expect(paths1).toStrictEqual({
       fromToken: {
         id: '1',
+        name: 'A',
         symbol: 'A',
         displaySymbol: 'dA'
       },
       toToken: {
         id: '0',
+        name: 'Default Defi token',
         symbol: 'DFI',
         displaySymbol: 'DFI'
       },
@@ -385,8 +387,8 @@ describe('get best path', () => {
           symbol: 'A-DFI',
           poolPairId: '15',
           priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-          tokenA: { id: '1', symbol: 'A', displaySymbol: 'dA' },
-          tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
+          tokenA: { id: '1', name: 'A', symbol: 'A', displaySymbol: 'dA' },
+          tokenB: { id: '0', name: 'Default Defi token', symbol: 'DFI', displaySymbol: 'DFI' }
         }
       ],
       estimatedReturn: '2.00000000',
@@ -399,11 +401,13 @@ describe('get best path', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '1',
+        name: 'A',
         symbol: 'A',
         displaySymbol: 'dA'
       },
       toToken: {
         id: '3',
+        name: 'C',
         symbol: 'C',
         displaySymbol: 'dC'
       },
@@ -412,15 +416,15 @@ describe('get best path', () => {
           symbol: 'A-DFI',
           poolPairId: '15',
           priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-          tokenA: { id: '1', symbol: 'A', displaySymbol: 'dA' },
-          tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
+          tokenA: { id: '1', name: 'A', symbol: 'A', displaySymbol: 'dA' },
+          tokenB: { id: '0', name: 'Default Defi token', symbol: 'DFI', displaySymbol: 'DFI' }
         },
         {
           symbol: 'C-DFI',
           poolPairId: '17',
           priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-          tokenA: { id: '3', symbol: 'C', displaySymbol: 'dC' },
-          tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
+          tokenA: { id: '3', name: 'C', symbol: 'C', displaySymbol: 'dC' },
+          tokenB: { id: '0', name: 'Default Defi token', symbol: 'DFI', displaySymbol: 'DFI' }
         }
       ],
       estimatedReturn: '0.50000000',
@@ -433,11 +437,13 @@ describe('get best path', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '7',
+        name: 'G',
         symbol: 'G',
         displaySymbol: 'dG'
       },
       toToken: {
         id: '3',
+        name: 'C',
         symbol: 'C',
         displaySymbol: 'dC'
       },
@@ -446,22 +452,22 @@ describe('get best path', () => {
           symbol: 'G-A',
           poolPairId: '21',
           priceRatio: { ab: '0.20000000', ba: '5.00000000' },
-          tokenA: { id: '7', symbol: 'G', displaySymbol: 'dG' },
-          tokenB: { id: '1', symbol: 'A', displaySymbol: 'dA' }
+          tokenA: { id: '7', name: 'G', symbol: 'G', displaySymbol: 'dG' },
+          tokenB: { id: '1', name: 'A', symbol: 'A', displaySymbol: 'dA' }
         },
         {
           symbol: 'A-DFI',
           poolPairId: '15',
           priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-          tokenA: { id: '1', symbol: 'A', displaySymbol: 'dA' },
-          tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
+          tokenA: { id: '1', name: 'A', symbol: 'A', displaySymbol: 'dA' },
+          tokenB: { id: '0', name: 'Default Defi token', symbol: 'DFI', displaySymbol: 'DFI' }
         },
         {
           symbol: 'C-DFI',
           poolPairId: '17',
           priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-          tokenA: { id: '3', symbol: 'C', displaySymbol: 'dC' },
-          tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
+          tokenA: { id: '3', name: 'C', symbol: 'C', displaySymbol: 'dC' },
+          tokenB: { id: '0', name: 'Default Defi token', symbol: 'DFI', displaySymbol: 'DFI' }
         }
       ],
       estimatedReturn: '2.50000000',
@@ -478,11 +484,13 @@ describe('get best path', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '9',
+        name: 'I',
         symbol: 'I',
         displaySymbol: 'dI'
       },
       toToken: {
         id: '14',
+        name: 'N',
         symbol: 'N',
         displaySymbol: 'dN'
       },
@@ -499,11 +507,13 @@ describe('get best path', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '10',
+        name: 'J',
         symbol: 'J',
         displaySymbol: 'dJ'
       },
       toToken: {
         id: '11',
+        name: 'K',
         symbol: 'K',
         displaySymbol: 'dK'
       },
@@ -512,8 +522,8 @@ describe('get best path', () => {
           symbol: 'J-K',
           poolPairId: '23',
           priceRatio: { ab: '0.14285714', ba: '7.00000000' },
-          tokenA: { id: '10', symbol: 'J', displaySymbol: 'dJ' },
-          tokenB: { id: '11', symbol: 'K', displaySymbol: 'dK' }
+          tokenA: { id: '10', name: 'J', symbol: 'J', displaySymbol: 'dJ' },
+          tokenB: { id: '11', name: 'K', symbol: 'K', displaySymbol: 'dK' }
         }
       ],
       estimatedReturn: '7.00000000',
@@ -526,11 +536,13 @@ describe('get best path', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '8',
+        name: 'H',
         symbol: 'H',
         displaySymbol: 'dH'
       },
       toToken: {
         id: '1',
+        name: 'A',
         symbol: 'A',
         displaySymbol: 'dA'
       },
@@ -555,11 +567,13 @@ describe('get all paths', () => {
     expect(paths1).toStrictEqual({
       fromToken: {
         id: '1',
+        name: 'A',
         symbol: 'A',
         displaySymbol: 'dA'
       },
       toToken: {
         id: '0',
+        name: 'Default Defi token',
         symbol: 'DFI',
         displaySymbol: 'DFI'
       },
@@ -568,8 +582,8 @@ describe('get all paths', () => {
           {
             symbol: 'A-DFI',
             poolPairId: '15',
-            tokenA: { id: '1', symbol: 'A', displaySymbol: 'dA' },
-            tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' },
+            tokenA: { id: '1', name: 'A', symbol: 'A', displaySymbol: 'dA' },
+            tokenB: { id: '0', name: 'Default Defi token', symbol: 'DFI', displaySymbol: 'DFI' },
             priceRatio: { ab: '0.50000000', ba: '2.00000000' }
           }
         ]
@@ -582,11 +596,13 @@ describe('get all paths', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '1',
+        name: 'A',
         symbol: 'A',
         displaySymbol: 'dA'
       },
       toToken: {
         id: '3',
+        name: 'C',
         symbol: 'C',
         displaySymbol: 'dC'
       },
@@ -596,15 +612,15 @@ describe('get all paths', () => {
             symbol: 'A-DFI',
             poolPairId: '15',
             priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-            tokenA: { id: '1', symbol: 'A', displaySymbol: 'dA' },
-            tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
+            tokenA: { id: '1', name: 'A', symbol: 'A', displaySymbol: 'dA' },
+            tokenB: { id: '0', name: 'Default Defi token', symbol: 'DFI', displaySymbol: 'DFI' }
           },
           {
             symbol: 'C-DFI',
             poolPairId: '17',
             priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-            tokenA: { id: '3', symbol: 'C', displaySymbol: 'dC' },
-            tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
+            tokenA: { id: '3', name: 'C', symbol: 'C', displaySymbol: 'dC' },
+            tokenB: { id: '0', name: 'Default Defi token', symbol: 'DFI', displaySymbol: 'DFI' }
           }
         ]
       ]
@@ -616,11 +632,13 @@ describe('get all paths', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '7',
+        name: 'G',
         symbol: 'G',
         displaySymbol: 'dG'
       },
       toToken: {
         id: '3',
+        name: 'C',
         symbol: 'C',
         displaySymbol: 'dC'
       },
@@ -630,22 +648,22 @@ describe('get all paths', () => {
             symbol: 'G-A',
             poolPairId: '21',
             priceRatio: { ab: '0.20000000', ba: '5.00000000' },
-            tokenA: { id: '7', symbol: 'G', displaySymbol: 'dG' },
-            tokenB: { id: '1', symbol: 'A', displaySymbol: 'dA' }
+            tokenA: { id: '7', name: 'G', symbol: 'G', displaySymbol: 'dG' },
+            tokenB: { id: '1', name: 'A', symbol: 'A', displaySymbol: 'dA' }
           },
           {
             symbol: 'A-DFI',
             poolPairId: '15',
             priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-            tokenA: { id: '1', symbol: 'A', displaySymbol: 'dA' },
-            tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
+            tokenA: { id: '1', name: 'A', symbol: 'A', displaySymbol: 'dA' },
+            tokenB: { id: '0', name: 'Default Defi token', symbol: 'DFI', displaySymbol: 'DFI' }
           },
           {
             symbol: 'C-DFI',
             poolPairId: '17',
             priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-            tokenA: { id: '3', symbol: 'C', displaySymbol: 'dC' },
-            tokenB: { id: '0', symbol: 'DFI', displaySymbol: 'DFI' }
+            tokenA: { id: '3', name: 'C', symbol: 'C', displaySymbol: 'dC' },
+            tokenB: { id: '0', name: 'Default Defi token', symbol: 'DFI', displaySymbol: 'DFI' }
           }
         ]
       ]
@@ -662,11 +680,13 @@ describe('get all paths', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '9',
+        name: 'I',
         symbol: 'I',
         displaySymbol: 'dI'
       },
       toToken: {
         id: '14',
+        name: 'N',
         symbol: 'N',
         displaySymbol: 'dN'
       },
@@ -679,11 +699,13 @@ describe('get all paths', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '9',
+        name: 'I',
         symbol: 'I',
         displaySymbol: 'dI'
       },
       toToken: {
         id: '11',
+        name: 'K',
         symbol: 'K',
         displaySymbol: 'dK'
       },
@@ -693,22 +715,22 @@ describe('get all paths', () => {
             symbol: 'I-J',
             poolPairId: '22',
             priceRatio: { ab: '0', ba: '0' },
-            tokenA: { id: '9', symbol: 'I', displaySymbol: 'dI' },
-            tokenB: { id: '10', symbol: 'J', displaySymbol: 'dJ' }
+            tokenA: { id: '9', name: 'I', symbol: 'I', displaySymbol: 'dI' },
+            tokenB: { id: '10', name: 'J', symbol: 'J', displaySymbol: 'dJ' }
           },
           {
             symbol: 'J-L',
             poolPairId: '24',
             priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-            tokenA: { id: '10', symbol: 'J', displaySymbol: 'dJ' },
-            tokenB: { id: '12', symbol: 'L', displaySymbol: 'dL' }
+            tokenA: { id: '10', name: 'J', symbol: 'J', displaySymbol: 'dJ' },
+            tokenB: { id: '12', name: 'L', symbol: 'L', displaySymbol: 'dL' }
           },
           {
             symbol: 'L-K',
             poolPairId: '25',
             priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-            tokenA: { id: '12', symbol: 'L', displaySymbol: 'dL' },
-            tokenB: { id: '11', symbol: 'K', displaySymbol: 'dK' }
+            tokenA: { id: '12', name: 'L', symbol: 'L', displaySymbol: 'dL' },
+            tokenB: { id: '11', name: 'K', symbol: 'K', displaySymbol: 'dK' }
           }
         ],
         [
@@ -716,15 +738,15 @@ describe('get all paths', () => {
             symbol: 'I-J',
             poolPairId: '22',
             priceRatio: { ab: '0', ba: '0' },
-            tokenA: { id: '9', symbol: 'I', displaySymbol: 'dI' },
-            tokenB: { id: '10', symbol: 'J', displaySymbol: 'dJ' }
+            tokenA: { id: '9', name: 'I', symbol: 'I', displaySymbol: 'dI' },
+            tokenB: { id: '10', name: 'J', symbol: 'J', displaySymbol: 'dJ' }
           },
           {
             symbol: 'J-K',
             poolPairId: '23',
             priceRatio: { ab: '0.14285714', ba: '7.00000000' },
-            tokenA: { id: '10', symbol: 'J', displaySymbol: 'dJ' },
-            tokenB: { id: '11', symbol: 'K', displaySymbol: 'dK' }
+            tokenA: { id: '10', name: 'J', symbol: 'J', displaySymbol: 'dJ' },
+            tokenB: { id: '11', name: 'K', symbol: 'K', displaySymbol: 'dK' }
           }
         ]
       ]
@@ -736,11 +758,13 @@ describe('get all paths', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '10',
+        name: 'J',
         symbol: 'J',
         displaySymbol: 'dJ'
       },
       toToken: {
         id: '11',
+        name: 'K',
         symbol: 'K',
         displaySymbol: 'dK'
       },
@@ -750,15 +774,15 @@ describe('get all paths', () => {
             symbol: 'J-L',
             poolPairId: '24',
             priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-            tokenA: { id: '10', symbol: 'J', displaySymbol: 'dJ' },
-            tokenB: { id: '12', symbol: 'L', displaySymbol: 'dL' }
+            tokenA: { id: '10', name: 'J', symbol: 'J', displaySymbol: 'dJ' },
+            tokenB: { id: '12', name: 'L', symbol: 'L', displaySymbol: 'dL' }
           },
           {
             symbol: 'L-K',
             poolPairId: '25',
             priceRatio: { ab: '0.25000000', ba: '4.00000000' },
-            tokenA: { id: '12', symbol: 'L', displaySymbol: 'dL' },
-            tokenB: { id: '11', symbol: 'K', displaySymbol: 'dK' }
+            tokenA: { id: '12', name: 'L', symbol: 'L', displaySymbol: 'dL' },
+            tokenB: { id: '11', name: 'K', symbol: 'K', displaySymbol: 'dK' }
           }
         ],
         [
@@ -766,8 +790,8 @@ describe('get all paths', () => {
             symbol: 'J-K',
             poolPairId: '23',
             priceRatio: { ab: '0.14285714', ba: '7.00000000' },
-            tokenA: { id: '10', symbol: 'J', displaySymbol: 'dJ' },
-            tokenB: { id: '11', symbol: 'K', displaySymbol: 'dK' }
+            tokenA: { id: '10', name: 'J', symbol: 'J', displaySymbol: 'dJ' },
+            tokenB: { id: '11', name: 'K', symbol: 'K', displaySymbol: 'dK' }
           }
         ]
       ]
@@ -779,11 +803,13 @@ describe('get all paths', () => {
     expect(response).toStrictEqual({
       fromToken: {
         id: '8',
+        name: 'H',
         symbol: 'H',
         displaySymbol: 'dH'
       },
       toToken: {
         id: '1',
+        name: 'A',
         symbol: 'A',
         displaySymbol: 'dA'
       },
@@ -812,16 +838,16 @@ describe('get list swappable tokens', () => {
   it('should list correct swappable tokens', async () => {
     const result = await controller.listSwappableTokens('1') // A
     expect(result).toStrictEqual({
-      fromToken: { id: '1', symbol: 'A', displaySymbol: 'dA' },
+      fromToken: { id: '1', name: 'A', symbol: 'A', displaySymbol: 'dA' },
       swappableTokens: [
-        { id: '7', symbol: 'G', displaySymbol: 'dG' },
-        { id: '0', symbol: 'DFI', displaySymbol: 'DFI' },
-        { id: '30', symbol: 'USDT', displaySymbol: 'dUSDT' },
-        { id: '6', symbol: 'F', displaySymbol: 'dF' },
-        { id: '5', symbol: 'E', displaySymbol: 'dE' },
-        { id: '4', symbol: 'D', displaySymbol: 'dD' },
-        { id: '3', symbol: 'C', displaySymbol: 'dC' },
-        { id: '2', symbol: 'B', displaySymbol: 'dB' }
+        { id: '7', name: 'G', symbol: 'G', displaySymbol: 'dG' },
+        { id: '0', name: 'Default Defi token', symbol: 'DFI', displaySymbol: 'DFI' },
+        { id: '30', name: 'USDT', symbol: 'USDT', displaySymbol: 'dUSDT' },
+        { id: '6', name: 'F', symbol: 'F', displaySymbol: 'dF' },
+        { id: '5', name: 'E', symbol: 'E', displaySymbol: 'dE' },
+        { id: '4', name: 'D', symbol: 'D', displaySymbol: 'dD' },
+        { id: '3', name: 'C', symbol: 'C', displaySymbol: 'dC' },
+        { id: '2', name: 'B', symbol: 'B', displaySymbol: 'dB' }
       ]
     })
   })
@@ -835,7 +861,7 @@ describe('get list swappable tokens', () => {
   it('should list no tokens for token that is not swappable with any', async () => {
     const result = await controller.listSwappableTokens('8') // H
     expect(result).toStrictEqual({
-      fromToken: { id: '8', symbol: 'H', displaySymbol: 'dH' },
+      fromToken: { id: '8', name: 'H', symbol: 'H', displaySymbol: 'dH' },
       swappableTokens: []
     })
   })
@@ -851,66 +877,66 @@ describe('latest dex prices', () => {
   it('should get latest dex prices - denomination: DFI', async () => {
     const result = await controller.listDexPrices('DFI')
     expect(result).toStrictEqual({
-      denomination: { displaySymbol: 'DFI', id: '0', symbol: 'DFI' },
+      denomination: { displaySymbol: 'DFI', id: '0', name: 'Default Defi token', symbol: 'DFI' },
       dexPrices: {
         USDT: {
-          token: { displaySymbol: 'dUSDT', id: '30', symbol: 'USDT' },
+          token: { displaySymbol: 'dUSDT', id: '30', name: 'USDT', symbol: 'USDT' },
           denominationPrice: '0.43151288'
         },
         N: {
-          token: { displaySymbol: 'dN', id: '14', symbol: 'N' },
+          token: { displaySymbol: 'dN', id: '14', name: 'N', symbol: 'N' },
           denominationPrice: '0'
         },
         M: {
-          token: { displaySymbol: 'dM', id: '13', symbol: 'M' },
+          token: { displaySymbol: 'dM', id: '13', name: 'M', symbol: 'M' },
           denominationPrice: '0'
         },
         L: {
-          token: { displaySymbol: 'dL', id: '12', symbol: 'L' },
+          token: { displaySymbol: 'dL', id: '12', name: 'L', symbol: 'L' },
           denominationPrice: '0'
         },
         K: {
-          token: { displaySymbol: 'dK', id: '11', symbol: 'K' },
+          token: { displaySymbol: 'dK', id: '11', name: 'K', symbol: 'K' },
           denominationPrice: '0'
         },
         J: {
-          token: { displaySymbol: 'dJ', id: '10', symbol: 'J' },
+          token: { displaySymbol: 'dJ', id: '10', name: 'J', symbol: 'J' },
           denominationPrice: '0'
         },
         I: {
-          token: { displaySymbol: 'dI', id: '9', symbol: 'I' },
+          token: { displaySymbol: 'dI', id: '9', name: 'I', symbol: 'I' },
           denominationPrice: '0'
         },
         H: {
-          token: { displaySymbol: 'dH', id: '8', symbol: 'H' },
+          token: { displaySymbol: 'dH', id: '8', name: 'H', symbol: 'H' },
           denominationPrice: '0'
         },
         G: {
-          token: { displaySymbol: 'dG', id: '7', symbol: 'G' },
+          token: { displaySymbol: 'dG', id: '7', name: 'G', symbol: 'G' },
           denominationPrice: '10.00000000'
         },
         F: {
-          token: { displaySymbol: 'dF', id: '6', symbol: 'F' },
+          token: { displaySymbol: 'dF', id: '6', name: 'F', symbol: 'F' },
           denominationPrice: '0'
         },
         E: {
-          token: { displaySymbol: 'dE', id: '5', symbol: 'E' },
+          token: { displaySymbol: 'dE', id: '5', name: 'E', symbol: 'E' },
           denominationPrice: '0'
         },
         D: {
-          token: { displaySymbol: 'dD', id: '4', symbol: 'D' },
+          token: { displaySymbol: 'dD', id: '4', name: 'D', symbol: 'D' },
           denominationPrice: '0'
         },
         C: {
-          token: { displaySymbol: 'dC', id: '3', symbol: 'C' },
+          token: { displaySymbol: 'dC', id: '3', name: 'C', symbol: 'C' },
           denominationPrice: '4.00000000'
         },
         B: {
-          token: { displaySymbol: 'dB', id: '2', symbol: 'B' },
+          token: { displaySymbol: 'dB', id: '2', name: 'B', symbol: 'B' },
           denominationPrice: '6.00000000'
         },
         A: {
-          token: { displaySymbol: 'dA', id: '1', symbol: 'A' },
+          token: { displaySymbol: 'dA', id: '1', name: 'A', symbol: 'A' },
           denominationPrice: '2.00000000'
         }
       }
@@ -920,66 +946,66 @@ describe('latest dex prices', () => {
   it('should get latest dex prices - denomination: USDT', async () => {
     const result = await controller.listDexPrices('USDT')
     expect(result).toStrictEqual({
-      denomination: { displaySymbol: 'dUSDT', id: '30', symbol: 'USDT' },
+      denomination: { displaySymbol: 'dUSDT', id: '30', name: 'USDT', symbol: 'USDT' },
       dexPrices: {
         DFI: {
-          token: { displaySymbol: 'DFI', id: '0', symbol: 'DFI' },
+          token: { displaySymbol: 'DFI', id: '0', name: 'Default Defi token', symbol: 'DFI' },
           denominationPrice: '2.31742792' // 1 DFI = 2.31 USDT
         },
         A: {
-          token: { displaySymbol: 'dA', id: '1', symbol: 'A' },
+          token: { displaySymbol: 'dA', id: '1', name: 'A', symbol: 'A' },
           denominationPrice: '4.63485584' // 1 A = 4.63 USDT
         },
         G: {
-          token: { displaySymbol: 'dG', id: '7', symbol: 'G' },
+          token: { displaySymbol: 'dG', id: '7', name: 'G', symbol: 'G' },
           denominationPrice: '23.17427920' // 1 G = 5 A = 10 DFI = 23 USDT
         },
         B: {
-          token: { displaySymbol: 'dB', id: '2', symbol: 'B' },
+          token: { displaySymbol: 'dB', id: '2', name: 'B', symbol: 'B' },
           denominationPrice: '13.90456752'
         },
         C: {
-          token: { displaySymbol: 'dC', id: '3', symbol: 'C' },
+          token: { displaySymbol: 'dC', id: '3', name: 'C', symbol: 'C' },
           denominationPrice: '9.26971168'
         },
         N: {
-          token: { displaySymbol: 'dN', id: '14', symbol: 'N' },
+          token: { displaySymbol: 'dN', id: '14', name: 'N', symbol: 'N' },
           denominationPrice: '0'
         },
         M: {
-          token: { displaySymbol: 'dM', id: '13', symbol: 'M' },
+          token: { displaySymbol: 'dM', id: '13', name: 'M', symbol: 'M' },
           denominationPrice: '0'
         },
         L: {
-          token: { displaySymbol: 'dL', id: '12', symbol: 'L' },
+          token: { displaySymbol: 'dL', id: '12', name: 'L', symbol: 'L' },
           denominationPrice: '0'
         },
         K: {
-          token: { displaySymbol: 'dK', id: '11', symbol: 'K' },
+          token: { displaySymbol: 'dK', id: '11', name: 'K', symbol: 'K' },
           denominationPrice: '0'
         },
         J: {
-          token: { displaySymbol: 'dJ', id: '10', symbol: 'J' },
+          token: { displaySymbol: 'dJ', id: '10', name: 'J', symbol: 'J' },
           denominationPrice: '0'
         },
         I: {
-          token: { displaySymbol: 'dI', id: '9', symbol: 'I' },
+          token: { displaySymbol: 'dI', id: '9', name: 'I', symbol: 'I' },
           denominationPrice: '0'
         },
         H: {
-          token: { displaySymbol: 'dH', id: '8', symbol: 'H' },
+          token: { displaySymbol: 'dH', id: '8', name: 'H', symbol: 'H' },
           denominationPrice: '0'
         },
         F: {
-          token: { displaySymbol: 'dF', id: '6', symbol: 'F' },
+          token: { displaySymbol: 'dF', id: '6', name: 'F', symbol: 'F' },
           denominationPrice: '0'
         },
         E: {
-          token: { displaySymbol: 'dE', id: '5', symbol: 'E' },
+          token: { displaySymbol: 'dE', id: '5', name: 'E', symbol: 'E' },
           denominationPrice: '0'
         },
         D: {
-          token: { displaySymbol: 'dD', id: '4', symbol: 'D' },
+          token: { displaySymbol: 'dD', id: '4', name: 'D', symbol: 'D' },
           denominationPrice: '0'
         }
       }

--- a/apps/whale-api/src/module.api/poolpair.controller.e2e.ts
+++ b/apps/whale-api/src/module.api/poolpair.controller.e2e.ts
@@ -210,6 +210,7 @@ describe('list', () => {
       status: true,
       tokenA: {
         id: '2',
+        name: 'B',
         symbol: 'B',
         reserve: '50',
         blockCommission: '0',
@@ -222,6 +223,7 @@ describe('list', () => {
       },
       tokenB: {
         id: '0',
+        name: 'Default Defi token',
         symbol: 'DFI',
         reserve: '300',
         blockCommission: '0',
@@ -307,6 +309,7 @@ describe('get', () => {
       status: true,
       tokenA: {
         id: expect.any(String),
+        name: 'A',
         symbol: 'A',
         reserve: '100',
         blockCommission: '0',
@@ -315,6 +318,7 @@ describe('get', () => {
       },
       tokenB: {
         id: '0',
+        name: 'Default Defi token',
         symbol: 'DFI',
         reserve: '200',
         blockCommission: '0',

--- a/apps/whale-api/src/module.api/poolpair.controller.ts
+++ b/apps/whale-api/src/module.api/poolpair.controller.ts
@@ -15,6 +15,7 @@ import { PoolPairService } from './poolpair.service'
 import { PoolSwapPathFindingService } from './poolswap.pathfinding.service'
 import BigNumber from 'bignumber.js'
 import { PoolPairInfo } from '@defichain/jellyfish-api-core/dist/category/poolpair'
+import { TokenInfo } from '@defichain/jellyfish-api-core/dist/category/token'
 import { parseDATSymbol } from './token.controller'
 import { PoolSwapMapper } from '../module.model/pool.swap'
 import { PoolSwapAggregatedMapper } from '../module.model/pool.swap.aggregated'
@@ -55,6 +56,8 @@ export class PoolPairController {
       const totalLiquidityUsd = await this.poolPairService.getTotalLiquidityUsd(info)
       const apr = await this.poolPairService.getAPR(id, info)
       const volume = await this.poolPairService.getUSDVolume(id)
+      info.nameTokenA = (await this.deFiDCache.getTokenInfo(info.idTokenA) as TokenInfo).name
+      info.nameTokenB = (await this.deFiDCache.getTokenInfo(info.idTokenB) as TokenInfo).name
       items.push(mapPoolPair(id, info, totalLiquidityUsd, apr, volume))
     }
 
@@ -81,6 +84,8 @@ export class PoolPairController {
     const totalLiquidityUsd = await this.poolPairService.getTotalLiquidityUsd(info)
     const apr = await this.poolPairService.getAPR(id, info)
     const volume = await this.poolPairService.getUSDVolume(id)
+    info.nameTokenA = (await this.deFiDCache.getTokenInfo(info.idTokenA) as TokenInfo).name
+    info.nameTokenB = (await this.deFiDCache.getTokenInfo(info.idTokenB) as TokenInfo).name
     return mapPoolPair(String(id), info, totalLiquidityUsd, apr, volume)
   }
 
@@ -203,7 +208,6 @@ function mapPoolPair (
   volume?: PoolPairData['volume']
 ): PoolPairData {
   const [symbolA, symbolB] = info.symbol.split('-')
-  const [nameA, nameB] = info.name.split('-')
 
   return {
     id: id,
@@ -215,7 +219,7 @@ function mapPoolPair (
       symbol: symbolA,
       displaySymbol: parseDATSymbol(symbolA),
       id: info.idTokenA,
-      name: nameA,
+      name: info.nameTokenA,
       reserve: info.reserveA.toFixed(),
       blockCommission: info.blockCommissionA.toFixed(),
       fee: info.dexFeePctTokenA !== undefined
@@ -230,7 +234,7 @@ function mapPoolPair (
       symbol: symbolB,
       displaySymbol: parseDATSymbol(symbolB),
       id: info.idTokenB,
-      name: nameB,
+      name: info.nameTokenB,
       reserve: info.reserveB.toFixed(),
       blockCommission: info.blockCommissionB.toFixed(),
       fee: info.dexFeePctTokenB !== undefined

--- a/apps/whale-api/src/module.api/poolpair.controller.ts
+++ b/apps/whale-api/src/module.api/poolpair.controller.ts
@@ -203,6 +203,7 @@ function mapPoolPair (
   volume?: PoolPairData['volume']
 ): PoolPairData {
   const [symbolA, symbolB] = info.symbol.split('-')
+  const [nameA, nameB] = info.name.split('-')
 
   return {
     id: id,
@@ -214,6 +215,7 @@ function mapPoolPair (
       symbol: symbolA,
       displaySymbol: parseDATSymbol(symbolA),
       id: info.idTokenA,
+      name: nameA,
       reserve: info.reserveA.toFixed(),
       blockCommission: info.blockCommissionA.toFixed(),
       fee: info.dexFeePctTokenA !== undefined
@@ -228,6 +230,7 @@ function mapPoolPair (
       symbol: symbolB,
       displaySymbol: parseDATSymbol(symbolB),
       id: info.idTokenB,
+      name: nameB,
       reserve: info.reserveB.toFixed(),
       blockCommission: info.blockCommissionB.toFixed(),
       fee: info.dexFeePctTokenB !== undefined

--- a/apps/whale-api/src/module.api/poolpair.fees.service.e2e.ts
+++ b/apps/whale-api/src/module.api/poolpair.fees.service.e2e.ts
@@ -203,11 +203,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dCAT',
           id: '3',
+          name: 'CAT',
           symbol: 'CAT'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])
@@ -231,11 +233,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dCAT',
           id: '3',
+          name: 'CAT',
           symbol: 'CAT'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])
@@ -259,11 +263,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dDOG',
           id: '5',
+          name: 'DOG',
           symbol: 'DOG'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])
@@ -287,11 +293,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dDOG',
           id: '5',
+          name: 'DOG',
           symbol: 'DOG'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])
@@ -315,11 +323,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dKOALA',
           id: '7',
+          name: 'KOALA',
           symbol: 'KOALA'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])
@@ -343,11 +353,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dKOALA',
           id: '7',
+          name: 'KOALA',
           symbol: 'KOALA'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])
@@ -371,11 +383,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dFISH',
           id: '9',
+          name: 'FISH',
           symbol: 'FISH'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])
@@ -398,11 +412,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dFISH',
           id: '9',
+          name: 'FISH',
           symbol: 'FISH'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])
@@ -426,11 +442,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dTURTLE',
           id: '11',
+          name: 'TURTLE',
           symbol: 'TURTLE'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])
@@ -455,11 +473,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dPANDA',
           id: '13',
+          name: 'PANDA',
           symbol: 'PANDA'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])
@@ -484,11 +504,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dRABBIT',
           id: '15',
+          name: 'RABBIT',
           symbol: 'RABBIT'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])
@@ -513,11 +535,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dFOX',
           id: '17',
+          name: 'FOX',
           symbol: 'FOX'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])
@@ -542,11 +566,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dLION',
           id: '19',
+          name: 'LION',
           symbol: 'LION'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])
@@ -571,11 +597,13 @@ describe('get best path - DEX burn fees', () => {
         tokenA: {
           displaySymbol: 'dTIGER',
           id: '21',
+          name: 'TIGER',
           symbol: 'TIGER'
         },
         tokenB: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         }
       }])

--- a/apps/whale-api/src/module.api/poolpair.prices.service.ts
+++ b/apps/whale-api/src/module.api/poolpair.prices.service.ts
@@ -96,6 +96,7 @@ export class PoolPairPricesService {
 function mapToTokenIdentifier (token: TokenInfoWithId): TokenIdentifier {
   return {
     id: token.id,
+    name: token.name,
     symbol: token.symbol,
     displaySymbol: parseDisplaySymbol(token)
   }

--- a/apps/whale-api/src/module.api/poolswap.pathfinding.service.ts
+++ b/apps/whale-api/src/module.api/poolswap.pathfinding.service.ts
@@ -226,6 +226,7 @@ export class PoolSwapPathFindingService {
     }
     return {
       id: tokenId,
+      name: tokenInfo.name,
       symbol: tokenInfo.symbol,
       displaySymbol: parseDisplaySymbol(tokenInfo)
     }

--- a/packages/jellyfish-api-core/src/category/poolpair.ts
+++ b/packages/jellyfish-api-core/src/category/poolpair.ts
@@ -201,6 +201,8 @@ export interface PoolPairInfo {
   status: boolean
   idTokenA: string
   idTokenB: string
+  nameTokenA: string
+  nameTokenB: string
   dexFeePctTokenA?: BigNumber
   dexFeeInPctTokenA?: BigNumber
   dexFeeOutPctTokenA?: BigNumber

--- a/packages/jellyfish-api-core/src/category/poolpair.ts
+++ b/packages/jellyfish-api-core/src/category/poolpair.ts
@@ -201,8 +201,6 @@ export interface PoolPairInfo {
   status: boolean
   idTokenA: string
   idTokenB: string
-  nameTokenA: string
-  nameTokenB: string
   dexFeePctTokenA?: BigNumber
   dexFeeInPctTokenA?: BigNumber
   dexFeeOutPctTokenA?: BigNumber

--- a/packages/whale-api-client/__tests__/api/poolpairs.test.ts
+++ b/packages/whale-api-client/__tests__/api/poolpairs.test.ts
@@ -148,6 +148,7 @@ describe('poolpair info', () => {
       status: true,
       tokenA: {
         id: '2',
+        name: 'B',
         symbol: 'B',
         reserve: '50',
         blockCommission: '0',
@@ -155,6 +156,7 @@ describe('poolpair info', () => {
       },
       tokenB: {
         id: '0',
+        name: 'Default Defi token',
         symbol: 'DFI',
         reserve: '300',
         blockCommission: '0',
@@ -231,6 +233,7 @@ describe('poolpair info', () => {
       status: true,
       tokenA: {
         id: expect.any(String),
+        name: 'A',
         symbol: 'A',
         reserve: '100',
         blockCommission: '0',
@@ -238,6 +241,7 @@ describe('poolpair info', () => {
       },
       tokenB: {
         id: '0',
+        name: 'Default Defi token',
         symbol: 'DFI',
         reserve: '200',
         blockCommission: '0',
@@ -283,6 +287,7 @@ describe('poolpair info', () => {
       status: true,
       tokenA: {
         id: expect.any(String),
+        name: 'USDC',
         symbol: 'USDC',
         reserve: '500',
         blockCommission: '0',
@@ -290,6 +295,7 @@ describe('poolpair info', () => {
       },
       tokenB: {
         id: '8',
+        name: 'H',
         symbol: 'H',
         reserve: '31.51288',
         blockCommission: '0',
@@ -543,6 +549,7 @@ describe('poolswap', () => {
       status: true,
       tokenA: {
         id: expect.any(String),
+        name: 'A',
         symbol: 'A',
         reserve: '298',
         blockCommission: '0',
@@ -550,6 +557,7 @@ describe('poolswap', () => {
       },
       tokenB: {
         id: '0',
+        name: 'Default Defi token',
         symbol: 'DFI',
         reserve: '67.11409397',
         blockCommission: '0',
@@ -592,6 +600,7 @@ describe('poolswap', () => {
       status: true,
       tokenA: {
         id: expect.any(String),
+        name: 'TEST',
         symbol: 'TEST',
         reserve: '29.98',
         blockCommission: '0',
@@ -599,6 +608,7 @@ describe('poolswap', () => {
       },
       tokenB: {
         id: expect.any(String),
+        name: 'DUSD',
         symbol: 'DUSD',
         reserve: '66.71114077',
         blockCommission: '0',
@@ -676,6 +686,7 @@ describe('poolswap 24h', () => {
       status: true,
       tokenA: {
         id: expect.any(String),
+        name: 'A',
         symbol: 'A',
         reserve: '102.5',
         blockCommission: '0',
@@ -683,6 +694,7 @@ describe('poolswap 24h', () => {
       },
       tokenB: {
         id: '0',
+        name: 'Default Defi token',
         symbol: 'DFI',
         reserve: '195.12195134',
         blockCommission: '0',
@@ -836,20 +848,21 @@ describe('poolpair - swappable tokens', () => {
       expect(response).toStrictEqual({
         fromToken: {
           id: '1',
+          name: 'A',
           symbol: 'A',
           displaySymbol: 'dA'
         },
         swappableTokens: [
-          { id: '0', symbol: 'DFI', displaySymbol: 'DFI' },
-          { id: '17', symbol: 'USDT', displaySymbol: 'dUSDT' },
-          { id: '8', symbol: 'H', displaySymbol: 'dH' },
-          { id: '19', symbol: 'USDC', displaySymbol: 'dUSDC' },
-          { id: '7', symbol: 'G', displaySymbol: 'dG' },
-          { id: '6', symbol: 'F', displaySymbol: 'dF' },
-          { id: '5', symbol: 'E', displaySymbol: 'dE' },
-          { id: '4', symbol: 'D', displaySymbol: 'dD' },
-          { id: '3', symbol: 'C', displaySymbol: 'dC' },
-          { id: '2', symbol: 'B', displaySymbol: 'dB' }
+          { id: '0', name: 'Default Defi token', symbol: 'DFI', displaySymbol: 'DFI' },
+          { id: '17', name: 'USDT', symbol: 'USDT', displaySymbol: 'dUSDT' },
+          { id: '8', name: 'H', symbol: 'H', displaySymbol: 'dH' },
+          { id: '19', name: 'USDC', symbol: 'USDC', displaySymbol: 'dUSDC' },
+          { id: '7', name: 'G', symbol: 'G', displaySymbol: 'dG' },
+          { id: '6', name: 'F', symbol: 'F', displaySymbol: 'dF' },
+          { id: '5', name: 'E', symbol: 'E', displaySymbol: 'dE' },
+          { id: '4', name: 'D', symbol: 'D', displaySymbol: 'dD' },
+          { id: '3', name: 'C', symbol: 'C', displaySymbol: 'dC' },
+          { id: '2', name: 'B', symbol: 'B', displaySymbol: 'dB' }
         ]
       })
     })
@@ -885,11 +898,13 @@ describe('poolpair - best swap path', () => {
         fromToken: {
           displaySymbol: 'dA',
           id: '1',
+          name: 'A',
           symbol: 'A'
         },
         toToken: {
           displaySymbol: 'dB',
           id: '2',
+          name: 'B',
           symbol: 'B'
         },
         bestPath: [
@@ -903,11 +918,13 @@ describe('poolpair - best swap path', () => {
             tokenA: {
               displaySymbol: 'dA',
               id: '1',
+              name: 'A',
               symbol: 'A'
             },
             tokenB: {
               displaySymbol: 'DFI',
               id: '0',
+              name: 'Default Defi token',
               symbol: 'DFI'
             }
           },
@@ -921,11 +938,13 @@ describe('poolpair - best swap path', () => {
             tokenA: {
               displaySymbol: 'dB',
               id: '2',
+              name: 'B',
               symbol: 'B'
             },
             tokenB: {
               displaySymbol: 'DFI',
               id: '0',
+              name: 'Default Defi token',
               symbol: 'DFI'
             }
           }
@@ -963,23 +982,23 @@ describe('poolpair - all swap paths', () => {
     await waitForExpect(async () => {
       const response = await client.poolpairs.getAllPaths('1', '2') // A to B
       expect(response).toStrictEqual({
-        fromToken: { displaySymbol: 'dA', id: '1', symbol: 'A' },
-        toToken: { displaySymbol: 'dB', id: '2', symbol: 'B' },
+        fromToken: { displaySymbol: 'dA', id: '1', name: 'A', symbol: 'A' },
+        toToken: { displaySymbol: 'dB', id: '2', name: 'B', symbol: 'B' },
         paths: [
           [
             {
               symbol: 'A-DFI',
               poolPairId: '9',
               priceRatio: { ab: '0.50000000', ba: '2.00000000' },
-              tokenA: { displaySymbol: 'dA', id: '1', symbol: 'A' },
-              tokenB: { displaySymbol: 'DFI', id: '0', symbol: 'DFI' }
+              tokenA: { displaySymbol: 'dA', id: '1', name: 'A', symbol: 'A' },
+              tokenB: { displaySymbol: 'DFI', id: '0', name: 'Default Defi token', symbol: 'DFI' }
             },
             {
               symbol: 'B-DFI',
               poolPairId: '10',
               priceRatio: { ab: '0.16666666', ba: '6.00000000' },
-              tokenA: { displaySymbol: 'dB', id: '2', symbol: 'B' },
-              tokenB: { displaySymbol: 'DFI', id: '0', symbol: 'DFI' }
+              tokenA: { displaySymbol: 'dB', id: '2', name: 'B', symbol: 'B' },
+              tokenB: { displaySymbol: 'DFI', id: '0', name: 'Default Defi token', symbol: 'DFI' }
             }
           ]
         ]

--- a/packages/whale-api-client/__tests__/api/poolpairs.test.ts
+++ b/packages/whale-api-client/__tests__/api/poolpairs.test.ts
@@ -1015,56 +1015,57 @@ describe('poolpair - get dex prices', () => {
         denomination: {
           displaySymbol: 'DFI',
           id: '0',
+          name: 'Default Defi token',
           symbol: 'DFI'
         },
         dexPrices: {
           A: {
             denominationPrice: '2.00000000',
-            token: { displaySymbol: 'dA', id: '1', symbol: 'A' }
+            token: { displaySymbol: 'dA', id: '1', name: 'A', symbol: 'A' }
           },
           B: {
             denominationPrice: '6.00000000',
-            token: { displaySymbol: 'dB', id: '2', symbol: 'B' }
+            token: { displaySymbol: 'dB', id: '2', name: 'B', symbol: 'B' }
           },
           C: {
             denominationPrice: '4.00000000',
-            token: { displaySymbol: 'dC', id: '3', symbol: 'C' }
+            token: { displaySymbol: 'dC', id: '3', name: 'C', symbol: 'C' }
           },
           D: {
             denominationPrice: '0',
-            token: { displaySymbol: 'dD', id: '4', symbol: 'D' }
+            token: { displaySymbol: 'dD', id: '4', name: 'D', symbol: 'D' }
           },
           E: {
             denominationPrice: '0',
-            token: { displaySymbol: 'dE', id: '5', symbol: 'E' }
+            token: { displaySymbol: 'dE', id: '5', name: 'E', symbol: 'E' }
           },
           USDT: {
             denominationPrice: '0.43151288',
-            token: { displaySymbol: 'dUSDT', id: '17', symbol: 'USDT' }
+            token: { displaySymbol: 'dUSDT', id: '17', name: 'USDT', symbol: 'USDT' }
           },
           DUSD: {
             denominationPrice: '0',
-            token: { displaySymbol: 'DUSD', id: '21', symbol: 'DUSD' }
+            token: { displaySymbol: 'DUSD', id: '21', name: 'DUSD', symbol: 'DUSD' }
           },
           USDC: {
             denominationPrice: '0',
-            token: { displaySymbol: 'dUSDC', id: '19', symbol: 'USDC' }
+            token: { displaySymbol: 'dUSDC', id: '19', name: 'USDC', symbol: 'USDC' }
           },
           F: {
             denominationPrice: '0',
-            token: { displaySymbol: 'dF', id: '6', symbol: 'F' }
+            token: { displaySymbol: 'dF', id: '6', name: 'F', symbol: 'F' }
           },
           G: {
             denominationPrice: '0',
-            token: { displaySymbol: 'dG', id: '7', symbol: 'G' }
+            token: { displaySymbol: 'dG', id: '7', name: 'G', symbol: 'G' }
           },
           H: {
             denominationPrice: '0',
-            token: { displaySymbol: 'dH', id: '8', symbol: 'H' }
+            token: { displaySymbol: 'dH', id: '8', name: 'H', symbol: 'H' }
           },
           TEST: {
             denominationPrice: '0',
-            token: { displaySymbol: 'dTEST', id: '22', symbol: 'TEST' }
+            token: { displaySymbol: 'dTEST', id: '22', name: 'TEST', symbol: 'TEST' }
           }
         }
       })

--- a/packages/whale-api-client/src/api/poolpairs.ts
+++ b/packages/whale-api-client/src/api/poolpairs.ts
@@ -277,6 +277,7 @@ export interface SwapPathPoolPair {
 
 export interface TokenIdentifier {
   id: string
+  name: string
   symbol: string
   displaySymbol: string
 }

--- a/packages/whale-api-client/src/api/poolpairs.ts
+++ b/packages/whale-api-client/src/api/poolpairs.ts
@@ -112,6 +112,7 @@ export interface PoolPairData {
   status: boolean
   tokenA: {
     id: string
+    name: string
     symbol: string
     displaySymbol: string
     reserve: string // BigNumber
@@ -124,6 +125,7 @@ export interface PoolPairData {
   }
   tokenB: {
     id: string
+    name: string
     symbol: string
     displaySymbol: string
     reserve: string // BigNumber


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
On the redesigned screens for Token Selection (swap), we need to display the token name. In this PR, token name is added to the response of poolpairs apis.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:

- Affected endpoints: `/poolpairs`, `/poolpairs/paths/swappable/13`, `/poolpairs/dexprices`. There can be more affected routes, so definitely need the reviewers' help to check. 
- For `/poolpairs` api, `name` is added inside `tokenA` and `tokenB` data.

- Redesigned screen where we need to display the name:
![image](https://user-images.githubusercontent.com/17063281/188565549-018aea34-f280-465e-b6c4-1bed80812fae.png)
