### PR TITLE
feat(status-api): Implement oracle status for number of active oracles

### DIFF
--- a/apps/status-api/__tests__/controllers/OracleStatusController.test.ts
+++ b/apps/status-api/__tests__/controllers/OracleStatusController.test.ts
@@ -1,6 +1,7 @@
 import { StatusApiTesting } from '../../testing/StatusApiTesting'
 import { ApiPagedResponse, WhaleApiClient } from '@defichain/whale-api-client'
 import { Oracle, OraclePriceFeed } from '@defichain/whale-api-client/dist/api/oracles'
+import { PriceOracle, PriceTicker } from '@defichain/whale-api-client/dist/api/prices'
 
 const apiTesting = StatusApiTesting.create()
 
@@ -103,5 +104,188 @@ async function getMockedOracle (): Promise<Oracle> {
       currency: ''
     }],
     weightage: 0
+  }
+}
+
+describe('OracleStatusController - Oracle Active Status test', () => {
+  it('/oracles/<token>-<currency> - should get operational if 3 or more active', async () => {
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
+      .mockReturnValueOnce(getMockedPriceOracle(3))
+
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'get')
+      .mockReturnValueOnce(getMockedPriceTicker(3))
+
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: 'oracles/AMZN/USD'
+    })
+    expect(res.json()).toStrictEqual({
+      status: 'operational'
+    })
+    expect(res.statusCode).toStrictEqual(200)
+  })
+
+  it('/oracles/<token>-<currency> - should get outage if less than 3 active', async () => {
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
+      .mockReturnValueOnce(getMockedPriceOracle(3))
+
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'get')
+      .mockReturnValueOnce(getMockedPriceTicker(2))
+
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: 'oracles/DFI/USD'
+    })
+    expect(res.json()).toStrictEqual({
+      status: 'outage'
+    })
+    expect(res.statusCode).toStrictEqual(200)
+  })
+
+  it('/oracles/<token>-<currency> - should get outage if less than 75% active', async () => {
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
+      .mockReturnValueOnce(getMockedPriceOracle(5))
+
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'get')
+      .mockReturnValueOnce(getMockedPriceTicker(3))
+
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: 'oracles/GME/USD'
+    })
+    expect(res.json()).toStrictEqual({
+      status: 'outage'
+    })
+    expect(res.statusCode).toStrictEqual(200)
+  })
+
+  it('/oracles/<token>-<currency> - should get data from cache', async () => {
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
+      .mockReturnValueOnce(getMockedPriceOracle(5))
+
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'get')
+      .mockReturnValueOnce(getMockedPriceTicker(3))
+
+    const res1 = await apiTesting.app.inject({
+      method: 'GET',
+      url: 'oracles/ETH/USD'
+    })
+    const result1 = res1.json()
+
+    // These value for the mock will not be used as it will get the results from the cache
+    // If these mock values are invoked, the test will fail
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
+      .mockReturnValueOnce(getMockedPriceOracle(5))
+
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'get')
+      .mockReturnValueOnce(getMockedPriceTicker(5))
+
+    const res2 = await apiTesting.app.inject({
+      method: 'GET',
+      url: 'oracles/ETH/USD'
+    })
+    const result2 = res2.json()
+
+    expect(result1).toStrictEqual(result2)
+  })
+
+  it('/oracles/<token>-<currency> - should not get data from cache after 5 seconds', async () => {
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
+      .mockReturnValueOnce(getMockedPriceOracle(5))
+
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'get')
+      .mockReturnValueOnce(getMockedPriceTicker(3))
+
+    const res1 = await apiTesting.app.inject({
+      method: 'GET',
+      url: 'oracles/ETH/USD'
+    })
+    const result1 = res1.json()
+
+    // Wait for 5 seconds for cache to be invalidated
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
+      .mockReturnValueOnce(getMockedPriceOracle(5))
+
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'get')
+      .mockReturnValueOnce(getMockedPriceTicker(5))
+
+    const res2 = await apiTesting.app.inject({
+      method: 'GET',
+      url: 'oracles/ETH/USD'
+    })
+    const result2 = res2.json()
+
+    expect(result1).not.toStrictEqual(result2)
+  })
+})
+
+async function getMockedPriceOracle (numberOfOracles: number): Promise<ApiPagedResponse<PriceOracle>> {
+  const data = []
+
+  while (numberOfOracles-- > 0) {
+    data.push({
+      feed: {
+        id: '',
+        key: '',
+        sort: '',
+        token: '',
+        currency: '',
+        oracleId: '',
+        txid: '',
+        time: 0,
+        amount: '',
+        block: {
+          hash: '',
+          height: 0,
+          time: 0,
+          medianTime: 0
+        }
+      },
+      key: '',
+      oracleId: '',
+      token: '',
+      id: '',
+      block: {
+        hash: '',
+        height: 0,
+        medianTime: 0,
+        time: 0
+      },
+      currency: '',
+      weightage: 0
+    })
+  }
+  return new ApiPagedResponse({
+    data: data
+  }, 'GET', 'getOracles')
+}
+
+async function getMockedPriceTicker (active: number): Promise<PriceTicker> {
+  return {
+    id: '',
+    price: {
+      id: '',
+      key: '',
+      sort: '',
+      token: '',
+      currency: '',
+      aggregated: {
+        amount: '',
+        weightage: 0,
+        oracles: {
+          active: active,
+          total: 0
+        }
+      },
+      block: {
+        hash: '',
+        height: 0,
+        time: 0,
+        medianTime: 0
+      }
+    },
+    sort: ''
   }
 }

--- a/apps/status-api/__tests__/controllers/OracleStatusController.test.ts
+++ b/apps/status-api/__tests__/controllers/OracleStatusController.test.ts
@@ -108,7 +108,7 @@ async function getMockedOracle (): Promise<Oracle> {
 }
 
 describe('OracleStatusController - Oracle Active Status test', () => {
-  it('/oracles/ticker/<token>-<currency> - should get operational if at least 3 and 75% active', async () => {
+  it('/oracles/ticker/<token>-<currency> - should get operational if 3 active for total 3 oracles', async () => {
     jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
       .mockReturnValueOnce(getMockedPriceOracle(3))
 
@@ -125,12 +125,29 @@ describe('OracleStatusController - Oracle Active Status test', () => {
     expect(res.statusCode).toStrictEqual(200)
   })
 
-  it('/oracles/ticker/<token>-<currency> - should get outage if less than 3 active', async () => {
+  it('/oracles/ticker/<token>-<currency> - should get outage if at < 3 for total 3 oracles', async () => {
     jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
       .mockReturnValueOnce(getMockedPriceOracle(3))
 
     jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'get')
       .mockReturnValueOnce(getMockedPriceTicker(2))
+
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: 'oracles/ticker/USDT-USD'
+    })
+    expect(res.json()).toStrictEqual({
+      status: 'outage'
+    })
+    expect(res.statusCode).toStrictEqual(200)
+  })
+
+  it('/oracles/ticker/<token>-<currency> - should get outage if <= 3 active', async () => {
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
+      .mockReturnValueOnce(getMockedPriceOracle(5))
+
+    jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'get')
+      .mockReturnValueOnce(getMockedPriceTicker(3))
 
     const res = await apiTesting.app.inject({
       method: 'GET',
@@ -142,19 +159,19 @@ describe('OracleStatusController - Oracle Active Status test', () => {
     expect(res.statusCode).toStrictEqual(200)
   })
 
-  it('/oracles/ticker/<token>-<currency> - should get outage if less than 75% active', async () => {
+  it('/oracles/ticker/<token>-<currency> - should get operational if > 3 active', async () => {
     jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
       .mockReturnValueOnce(getMockedPriceOracle(5))
 
     jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'get')
-      .mockReturnValueOnce(getMockedPriceTicker(3))
+      .mockReturnValueOnce(getMockedPriceTicker(4))
 
     const res = await apiTesting.app.inject({
       method: 'GET',
       url: 'oracles/ticker/GME-USD'
     })
     expect(res.json()).toStrictEqual({
-      status: 'outage'
+      status: 'operational'
     })
     expect(res.statusCode).toStrictEqual(200)
   })

--- a/apps/status-api/__tests__/controllers/OracleStatusController.test.ts
+++ b/apps/status-api/__tests__/controllers/OracleStatusController.test.ts
@@ -108,7 +108,7 @@ async function getMockedOracle (): Promise<Oracle> {
 }
 
 describe('OracleStatusController - Oracle Active Status test', () => {
-  it('/oracles/<token>-<currency> - should get operational if 3 or more active', async () => {
+  it('/oracles/ticker/<token>-<currency> - should get operational if at least 3 and 75% active', async () => {
     jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
       .mockReturnValueOnce(getMockedPriceOracle(3))
 
@@ -117,7 +117,7 @@ describe('OracleStatusController - Oracle Active Status test', () => {
 
     const res = await apiTesting.app.inject({
       method: 'GET',
-      url: 'oracles/AMZN/USD'
+      url: 'oracles/ticker/AMZN-USD'
     })
     expect(res.json()).toStrictEqual({
       status: 'operational'
@@ -125,7 +125,7 @@ describe('OracleStatusController - Oracle Active Status test', () => {
     expect(res.statusCode).toStrictEqual(200)
   })
 
-  it('/oracles/<token>-<currency> - should get outage if less than 3 active', async () => {
+  it('/oracles/ticker/<token>-<currency> - should get outage if less than 3 active', async () => {
     jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
       .mockReturnValueOnce(getMockedPriceOracle(3))
 
@@ -134,7 +134,7 @@ describe('OracleStatusController - Oracle Active Status test', () => {
 
     const res = await apiTesting.app.inject({
       method: 'GET',
-      url: 'oracles/DFI/USD'
+      url: 'oracles/ticker/DFI-USD'
     })
     expect(res.json()).toStrictEqual({
       status: 'outage'
@@ -142,7 +142,7 @@ describe('OracleStatusController - Oracle Active Status test', () => {
     expect(res.statusCode).toStrictEqual(200)
   })
 
-  it('/oracles/<token>-<currency> - should get outage if less than 75% active', async () => {
+  it('/oracles/ticker/<token>-<currency> - should get outage if less than 75% active', async () => {
     jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
       .mockReturnValueOnce(getMockedPriceOracle(5))
 
@@ -151,7 +151,7 @@ describe('OracleStatusController - Oracle Active Status test', () => {
 
     const res = await apiTesting.app.inject({
       method: 'GET',
-      url: 'oracles/GME/USD'
+      url: 'oracles/ticker/GME-USD'
     })
     expect(res.json()).toStrictEqual({
       status: 'outage'
@@ -159,7 +159,7 @@ describe('OracleStatusController - Oracle Active Status test', () => {
     expect(res.statusCode).toStrictEqual(200)
   })
 
-  it('/oracles/<token>-<currency> - should get data from cache', async () => {
+  it('/oracles/ticker/<token>-<currency> - should get data from cache', async () => {
     jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
       .mockReturnValueOnce(getMockedPriceOracle(5))
 
@@ -168,7 +168,7 @@ describe('OracleStatusController - Oracle Active Status test', () => {
 
     const res1 = await apiTesting.app.inject({
       method: 'GET',
-      url: 'oracles/ETH/USD'
+      url: 'oracles/ticker/ETH-USD'
     })
     const result1 = res1.json()
 
@@ -182,14 +182,14 @@ describe('OracleStatusController - Oracle Active Status test', () => {
 
     const res2 = await apiTesting.app.inject({
       method: 'GET',
-      url: 'oracles/ETH/USD'
+      url: 'oracles/ticker/ETH-USD'
     })
     const result2 = res2.json()
 
     expect(result1).toStrictEqual(result2)
   })
 
-  it('/oracles/<token>-<currency> - should not get data from cache after 5 seconds', async () => {
+  it('/oracles/ticker/<token>-<currency> - should not get data from cache after 5 seconds', async () => {
     jest.spyOn(apiTesting.app.get(WhaleApiClient).prices, 'getOracles')
       .mockReturnValueOnce(getMockedPriceOracle(5))
 
@@ -198,7 +198,7 @@ describe('OracleStatusController - Oracle Active Status test', () => {
 
     const res1 = await apiTesting.app.inject({
       method: 'GET',
-      url: 'oracles/ETH/USD'
+      url: 'oracles/ticker/ETH-USD'
     })
     const result1 = res1.json()
 
@@ -213,7 +213,7 @@ describe('OracleStatusController - Oracle Active Status test', () => {
 
     const res2 = await apiTesting.app.inject({
       method: 'GET',
-      url: 'oracles/ETH/USD'
+      url: 'oracles/ticker/ETH-USD'
     })
     const result2 = res2.json()
 

--- a/apps/status-api/src/controllers/OracleStatusController.ts
+++ b/apps/status-api/src/controllers/OracleStatusController.ts
@@ -34,7 +34,7 @@ export class OracleStatusController {
    * @param token
    * @param currency
    */
-  @Get('/:token/:currency')
+  @Get('/ticker/:token-:currency')
   async getOracleRespondStatus (@Param('token') token: string, @Param('currency') currency: string): Promise<{ status: OracleStatus }> {
     return await this.cachedGet(`oracle-${token}-${currency}`, async () => {
       const oracles = await this.client.prices.getOracles(token, currency, 60)
@@ -43,7 +43,7 @@ export class OracleStatusController {
       const prices = await this.client.prices.get(token, currency)
       const active = prices.price.aggregated.oracles.active
 
-      if (active > 3 || (active / total) >= 0.75) {
+      if (active >= 3 && (active / total) >= 0.75) {
         return { status: 'operational' }
       }
       return { status: 'outage' }

--- a/apps/status-api/src/controllers/OracleStatusController.ts
+++ b/apps/status-api/src/controllers/OracleStatusController.ts
@@ -43,10 +43,10 @@ export class OracleStatusController {
       const prices = await this.client.prices.get(token, currency)
       const active = prices.price.aggregated.oracles.active
 
-      if (active >= 3 && (active / total) >= 0.75) {
-        return { status: 'operational' }
+      if ((total > 3 && active <= 3) || (total <= 3 && active < 3)) {
+        return { status: 'outage' }
       }
-      return { status: 'outage' }
+      return { status: 'operational' }
     }, 5) // cache status result for 5 seconds
   }
 

--- a/apps/status-api/src/modules/ControllerModule.ts
+++ b/apps/status-api/src/modules/ControllerModule.ts
@@ -18,7 +18,6 @@ import { NetworkName } from '@defichain/jellyfish-network'
   controllers: [
     ActuatorController,
     BlockchainStatusController,
-    ActuatorController,
     OracleStatusController,
     OverallStatusController
   ],


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
To add another oracle status api that returns the status of each ticker e.g. DFI/USD instead of the existing per oracle address. This increases the meaningfulness of each status return to create better monitoring for our oracle health.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/JellyfishSDK/jellyfish/issues/1748

#### Additional comments?:

cc: @joeldavidw 