### PR TITLE
feat(jellyfish-api-core): add blockchain getTxOutSetInfo RPC

### DIFF
--- a/docs/node/CATEGORIES/01-blockchain.md
+++ b/docs/node/CATEGORIES/01-blockchain.md
@@ -226,6 +226,28 @@ interface ScriptPubKey {
 }
 ```
 
+## getTxOutSetInfo
+
+Returns statistics about the unspent transaction output set.
+Note this call may take some time.
+
+```ts title="client.blockchain.getTxOutSetInfo()"
+interface blockchain {
+  getTxOutSetInfo (): Promise<TxOutSetInfo>
+}
+
+interface TxOutSetInfo {
+  height: number
+  bestblock: string
+  transactions: Number
+  txouts: Number
+  bogosize: Number
+  hash_serialized_2: string
+  disk_size: Number
+  total_amount: BigNumber
+}
+```
+
 ## getRawMempool
 
 Get all transaction ids in memory pool as string[] if verbose is false else as json object

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getTxOutSetInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getTxOutSetInfo.test.ts
@@ -1,0 +1,31 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { ContainerAdapterClient } from '../../container_adapter_client'
+import BigNumber from 'bignumber.js'
+
+describe('TxOutSetInfo', () => {
+  const container = new MasterNodeRegTestContainer()
+  const client = new ContainerAdapterClient(container)
+
+  beforeAll(async () => {
+    await container.start()
+    await container.generate(1)
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should getTxOutSetInfo', async () => {
+    const txOutSetInfo = await client.blockchain.getTxOutSetInfo()
+
+    expect(txOutSetInfo.height).toBeGreaterThanOrEqual(1)
+    expect(txOutSetInfo).toHaveProperty('bestblock')
+    expect(txOutSetInfo.transactions).toBeGreaterThanOrEqual(1)
+    expect(txOutSetInfo.txouts).toBeGreaterThanOrEqual(1)
+    expect(txOutSetInfo.bogosize).toBeGreaterThanOrEqual(1)
+    expect(txOutSetInfo).toHaveProperty('hash_serialized_2')
+    expect(txOutSetInfo.disk_size).toBeGreaterThanOrEqual(0)
+    expect(txOutSetInfo.total_amount instanceof BigNumber).toStrictEqual(true)
+    expect(txOutSetInfo.total_amount.toNumber()).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getTxOutSetInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getTxOutSetInfo.test.ts
@@ -19,7 +19,7 @@ describe('TxOutSetInfo', () => {
     const txOutSetInfo = await client.blockchain.getTxOutSetInfo()
 
     expect(txOutSetInfo).toStrictEqual({
-      height: expect.any(Number),
+      height: 2,
       bestblock: expect.any(String),
       transactions: expect.any(Number),
       txouts: expect.any(Number),

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getTxOutSetInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getTxOutSetInfo.test.ts
@@ -18,14 +18,15 @@ describe('TxOutSetInfo', () => {
   it('should getTxOutSetInfo', async () => {
     const txOutSetInfo = await client.blockchain.getTxOutSetInfo()
 
-    expect(txOutSetInfo.height).toBeGreaterThanOrEqual(1)
-    expect(txOutSetInfo).toHaveProperty('bestblock')
-    expect(txOutSetInfo.transactions).toBeGreaterThanOrEqual(1)
-    expect(txOutSetInfo.txouts).toBeGreaterThanOrEqual(1)
-    expect(txOutSetInfo.bogosize).toBeGreaterThanOrEqual(1)
-    expect(txOutSetInfo).toHaveProperty('hash_serialized_2')
-    expect(txOutSetInfo.disk_size).toBeGreaterThanOrEqual(0)
-    expect(txOutSetInfo.total_amount instanceof BigNumber).toStrictEqual(true)
-    expect(txOutSetInfo.total_amount.toNumber()).toBeGreaterThanOrEqual(1)
+    expect(txOutSetInfo).toStrictEqual({
+      height: 1,
+      bestblock: expect.any(String),
+      transactions: 10,
+      txouts: 15,
+      bogosize: 1117,
+      hash_serialized_2: expect.any(String),
+      disk_size: 0,
+      total_amount: new BigNumber(400000259.8)
+    })
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getTxOutSetInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getTxOutSetInfo.test.ts
@@ -8,7 +8,7 @@ describe('TxOutSetInfo', () => {
 
   beforeAll(async () => {
     await container.start()
-    await container.generate(1)
+    await container.waitForBlockHeight(1)
   })
 
   afterAll(async () => {
@@ -19,14 +19,14 @@ describe('TxOutSetInfo', () => {
     const txOutSetInfo = await client.blockchain.getTxOutSetInfo()
 
     expect(txOutSetInfo).toStrictEqual({
-      height: 1,
+      height: expect.any(Number),
       bestblock: expect.any(String),
-      transactions: 10,
-      txouts: 15,
-      bogosize: 1117,
+      transactions: expect.any(Number),
+      txouts: expect.any(Number),
+      bogosize: expect.any(Number),
       hash_serialized_2: expect.any(String),
-      disk_size: 0,
-      total_amount: new BigNumber(400000259.8)
+      disk_size: expect.any(Number),
+      total_amount: expect.any(BigNumber)
     })
   })
 })

--- a/packages/jellyfish-api-core/src/category/blockchain.ts
+++ b/packages/jellyfish-api-core/src/category/blockchain.ts
@@ -138,6 +138,18 @@ export class Blockchain {
   }
 
   /**
+   * Returns statistics about the unspent transaction output set.
+   * Note this call may take some time.
+   *
+   * @return {Promise<TxOutSetInfo>}
+   */
+  async getTxOutSetInfo (): Promise<TxOutSetInfo> {
+    return await this.client.call('gettxoutsetinfo', [], {
+      total_amount: 'bignumber'
+    })
+  }
+
+  /**
    * Get all transaction ids in memory pool as string
    *
    * @param {boolean} verbose false
@@ -341,6 +353,17 @@ export interface UTXODetails {
   value: BigNumber
   scriptPubKey: ScriptPubKey
   coinbase: boolean
+}
+
+export interface TxOutSetInfo {
+  height: number
+  bestblock: string
+  transactions: Number
+  txouts: Number
+  bogosize: Number
+  hash_serialized_2: string
+  disk_size: Number
+  total_amount: BigNumber
 }
 
 export interface ScriptPubKey {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
/kind feature

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes part of #48 
- Implements `gettxoutsetinfo` type for RPC.
