### PR TITLE
feat(jellyfish-api-core): add blockchain getMempoolAncestors RPC

### DIFF
--- a/docs/node/CATEGORIES/01-blockchain.md
+++ b/docs/node/CATEGORIES/01-blockchain.md
@@ -268,6 +268,50 @@ interface MempoolTx {
   }
 }
 ```
+
+## getMempoolAncestors
+
+Get all in-mempool ancestors if a transaction id is in mempool as string[] if verbose is false else as json object
+
+```ts title="client.blockchain.getMempoolAncestors()"
+interface blockchain {
+  getMempoolAncestors (txId: string, verbose?: false): Promise<string[]>
+  getMempoolAncestors (txId: string, verbose?: true): Promise<MempoolTx>
+  getMempoolAncestors (txId: string, verbose?: boolean: Promise<string[] | MempoolTx>
+}
+
+interface MempoolTx {
+  [key: string]: {
+    vsize: BigNumber
+    /**
+     * @deprecated same as vsize. Only returned if defid is started with -deprecatedrpc=size
+     */
+    size: BigNumber
+    weight: BigNumber
+    fee: BigNumber
+    modifiedfee: BigNumber
+    time: BigNumber
+    height: BigNumber
+    descendantcount: BigNumber
+    descendantsize: BigNumber
+    descendantfees: BigNumber
+    ancestorcount: BigNumber
+    ancestorsize: BigNumber
+    ancestorfees: BigNumber
+    wtxid: string
+    fees: {
+      base: BigNumber
+      modified: BigNumber
+      ancestor: BigNumber
+      descendant: BigNumber
+    }
+    depends: string[]
+    spentby: string[]
+    'bip125-replaceable': boolean
+  }
+}
+```
+
 ## getMempoolEntry
 
 Get transaction details in the memory pool using a transaction ID.

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolAncestors.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolAncestors.test.ts
@@ -1,0 +1,93 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { Testing } from '@defichain/jellyfish-testing'
+import BigNumber from 'bignumber.js'
+
+describe('getMempoolAncestors', () => {
+  const container = new MasterNodeRegTestContainer()
+  const testing = Testing.create(container)
+  const address = 'mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU'
+  const amount = 0.003
+
+  beforeAll(async () => {
+    await testing.container.start()
+    await testing.container.waitForWalletCoinbaseMaturity()
+  })
+
+  afterAll(async () => {
+    await testing.container.stop()
+  })
+
+  it('should return empty array for transaction id without ancestors', async () => {
+    const txId = await testing.rpc.wallet.sendToAddress(address, amount)
+    const mempoolEntry = await testing.rpc.blockchain.getMempoolAncestors(txId)
+
+    expect(mempoolEntry.length).toStrictEqual(0)
+  })
+
+  it('should return error if transaction is not in mempool', async () => {
+    const txId = '9fb9c46b1d12dae8a4a35558f7ef4b047df3b444b1ead61d334e4f187f5f58b7'
+    await expect(testing.rpc.blockchain.getMempoolAncestors(txId))
+      .rejects
+      .toThrowError('RpcApiError: \'Transaction not in mempool\', code: -5, method: getmempoolancestors')
+  })
+
+  it('should return error if transaction id has an invalid length', async () => {
+    await expect(testing.rpc.blockchain.getMempoolAncestors('invalidtxidstring'))
+      .rejects
+      .toThrow('RpcApiError: \'parameter 1 must be of length 64 (not 17, for \'invalidtxidstring\')\', code: -8, method: getmempoolancestors')
+  })
+
+  describe('transactions with ancestors', () => {
+    beforeAll(async () => {
+      for (let i = 0; i < 3; i++) {
+        await testing.rpc.wallet.sendToAddress(address, amount)
+      }
+    })
+
+    it('should return JSON object if verbose is true', async () => {
+      const txId = await testing.rpc.wallet.sendToAddress(address, amount)
+      const mempoolAncestors = await testing.rpc.blockchain.getMempoolAncestors(txId, true)
+      const keys = Object.keys(mempoolAncestors)
+      expect(keys.length).toBeGreaterThan(0)
+      for (const key of keys) {
+        expect(mempoolAncestors[key]).toStrictEqual({
+          fees: expect.any(Object),
+          vsize: expect.any(BigNumber),
+          weight: expect.any(BigNumber),
+          fee: expect.any(BigNumber),
+          modifiedfee: expect.any(BigNumber),
+          time: expect.any(BigNumber),
+          height: expect.any(BigNumber),
+          descendantcount: expect.any(BigNumber),
+          descendantsize: expect.any(BigNumber),
+          descendantfees: expect.any(BigNumber),
+          ancestorcount: expect.any(BigNumber),
+          ancestorsize: expect.any(BigNumber),
+          ancestorfees: expect.any(BigNumber),
+          wtxid: expect.any(String),
+          depends: expect.any(Array),
+          spentby: expect.any(Array),
+          'bip125-replaceable': expect.any(Boolean)
+        })
+      }
+    })
+
+    it('should return array of transaction ids if verbose is false', async () => {
+      const txId = await testing.rpc.wallet.sendToAddress(address, amount)
+      const mempoolAncestors = await testing.rpc.blockchain.getMempoolAncestors(txId, false)
+      expect(mempoolAncestors.length).toBeGreaterThan(0)
+      for (const ancestorId of mempoolAncestors) {
+        expect(ancestorId).toStrictEqual(expect.stringMatching(/^[0-f]{64}$/))
+      }
+    })
+
+    it('should return array of transaction ids if verbose is undefined', async () => {
+      const txId = await testing.rpc.wallet.sendToAddress(address, amount)
+      const mempoolAncestors = await testing.rpc.blockchain.getMempoolAncestors(txId)
+      expect(mempoolAncestors.length).toBeGreaterThan(0)
+      for (const ancestorId of mempoolAncestors) {
+        expect(ancestorId).toStrictEqual(expect.stringMatching(/^[0-f]{64}$/))
+      }
+    })
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolAncestors.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolAncestors.test.ts
@@ -2,11 +2,9 @@ import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { Testing } from '@defichain/jellyfish-testing'
 import BigNumber from 'bignumber.js'
 
-describe('getMempoolAncestors', () => {
+describe('transactions without ancestors', () => {
   const container = new MasterNodeRegTestContainer()
   const testing = Testing.create(container)
-  const address = 'mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU'
-  const amount = 0.003
 
   beforeAll(async () => {
     await testing.container.start()
@@ -36,58 +34,67 @@ describe('getMempoolAncestors', () => {
       .rejects
       .toThrow('RpcApiError: \'parameter 1 must be of length 64 (not 17, for \'invalidtxidstring\')\', code: -8, method: getmempoolancestors')
   })
+})
 
-  describe('transactions with ancestors', () => {
-    beforeAll(async () => {
-      for (let i = 0; i < 3; i++) {
-        await testing.rpc.wallet.sendToAddress(address, amount)
-      }
-    })
+describe('transactions with ancestors', () => {
+  const container = new MasterNodeRegTestContainer()
+  const testing = Testing.create(container)
 
-    it('should return JSON object if verbose is true', async () => {
-      const txId = await testing.rpc.wallet.sendToAddress(address, amount)
-      const mempoolAncestors = await testing.rpc.blockchain.getMempoolAncestors(txId, true)
-      const keys = Object.keys(mempoolAncestors)
-      expect(keys.length).toBeGreaterThan(0)
-      for (const key of keys) {
-        expect(mempoolAncestors[key]).toStrictEqual({
-          fees: expect.any(Object),
-          vsize: expect.any(BigNumber),
-          weight: expect.any(BigNumber),
-          fee: expect.any(BigNumber),
-          modifiedfee: expect.any(BigNumber),
-          time: expect.any(BigNumber),
-          height: expect.any(BigNumber),
-          descendantcount: expect.any(BigNumber),
-          descendantsize: expect.any(BigNumber),
-          descendantfees: expect.any(BigNumber),
-          ancestorcount: expect.any(BigNumber),
-          ancestorsize: expect.any(BigNumber),
-          ancestorfees: expect.any(BigNumber),
-          wtxid: expect.any(String),
-          depends: expect.any(Array),
-          spentby: expect.any(Array),
-          'bip125-replaceable': expect.any(Boolean)
-        })
-      }
-    })
+  beforeAll(async () => {
+    await testing.container.start()
+    await testing.container.waitForWalletCoinbaseMaturity()
+    for (let i = 0; i < 3; i++) {
+      await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.003)
+    }
+  })
 
-    it('should return array of transaction ids if verbose is false', async () => {
-      const txId = await testing.rpc.wallet.sendToAddress(address, amount)
-      const mempoolAncestors = await testing.rpc.blockchain.getMempoolAncestors(txId, false)
-      expect(mempoolAncestors.length).toBeGreaterThan(0)
-      for (const ancestorId of mempoolAncestors) {
-        expect(ancestorId).toStrictEqual(expect.stringMatching(/^[0-9a-f]{64}$/))
-      }
-    })
+  afterAll(async () => {
+    await testing.container.stop()
+  })
 
-    it('should return array of transaction ids if verbose is undefined', async () => {
-      const txId = await testing.rpc.wallet.sendToAddress(address, amount)
-      const mempoolAncestors = await testing.rpc.blockchain.getMempoolAncestors(txId)
-      expect(mempoolAncestors.length).toBeGreaterThan(0)
-      for (const ancestorId of mempoolAncestors) {
-        expect(ancestorId).toStrictEqual(expect.stringMatching(/^[0-9a-f]{64}$/))
-      }
-    })
+  it('should return JSON object if verbose is true', async () => {
+    const txId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.003)
+    const mempoolAncestors = await testing.rpc.blockchain.getMempoolAncestors(txId, true)
+    const keys = Object.keys(mempoolAncestors)
+    expect(keys.length).toBeGreaterThan(0)
+    for (const key of keys) {
+      expect(mempoolAncestors[key]).toStrictEqual({
+        fees: expect.any(Object),
+        vsize: expect.any(BigNumber),
+        weight: expect.any(BigNumber),
+        fee: expect.any(BigNumber),
+        modifiedfee: expect.any(BigNumber),
+        time: expect.any(BigNumber),
+        height: expect.any(BigNumber),
+        descendantcount: expect.any(BigNumber),
+        descendantsize: expect.any(BigNumber),
+        descendantfees: expect.any(BigNumber),
+        ancestorcount: expect.any(BigNumber),
+        ancestorsize: expect.any(BigNumber),
+        ancestorfees: expect.any(BigNumber),
+        wtxid: expect.any(String),
+        depends: expect.any(Array),
+        spentby: expect.any(Array),
+        'bip125-replaceable': expect.any(Boolean)
+      })
+    }
+  })
+
+  it('should return array of transaction ids if verbose is false', async () => {
+    const txId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.003)
+    const mempoolAncestors = await testing.rpc.blockchain.getMempoolAncestors(txId, false)
+    expect(mempoolAncestors.length).toBeGreaterThan(0)
+    for (const ancestorId of mempoolAncestors) {
+      expect(ancestorId).toStrictEqual(expect.stringMatching(/^[0-9a-f]{64}$/))
+    }
+  })
+
+  it('should return array of transaction ids if verbose is undefined', async () => {
+    const txId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.003)
+    const mempoolAncestors = await testing.rpc.blockchain.getMempoolAncestors(txId)
+    expect(mempoolAncestors.length).toBeGreaterThan(0)
+    for (const ancestorId of mempoolAncestors) {
+      expect(ancestorId).toStrictEqual(expect.stringMatching(/^[0-9a-f]{64}$/))
+    }
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolAncestors.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolAncestors.test.ts
@@ -18,7 +18,7 @@ describe('getMempoolAncestors', () => {
   })
 
   it('should return empty array for transaction id without ancestors', async () => {
-    const txId = await testing.rpc.wallet.sendToAddress(address, amount)
+    const txId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.003)
     const mempoolEntry = await testing.rpc.blockchain.getMempoolAncestors(txId)
 
     expect(mempoolEntry.length).toStrictEqual(0)

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolAncestors.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolAncestors.test.ts
@@ -77,7 +77,7 @@ describe('getMempoolAncestors', () => {
       const mempoolAncestors = await testing.rpc.blockchain.getMempoolAncestors(txId, false)
       expect(mempoolAncestors.length).toBeGreaterThan(0)
       for (const ancestorId of mempoolAncestors) {
-        expect(ancestorId).toStrictEqual(expect.stringMatching(/^[0-f]{64}$/))
+        expect(ancestorId).toStrictEqual(expect.stringMatching(/^[0-9a-f]{64}$/))
       }
     })
 

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolAncestors.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolAncestors.test.ts
@@ -86,7 +86,7 @@ describe('getMempoolAncestors', () => {
       const mempoolAncestors = await testing.rpc.blockchain.getMempoolAncestors(txId)
       expect(mempoolAncestors.length).toBeGreaterThan(0)
       for (const ancestorId of mempoolAncestors) {
-        expect(ancestorId).toStrictEqual(expect.stringMatching(/^[0-f]{64}$/))
+        expect(ancestorId).toStrictEqual(expect.stringMatching(/^[0-9a-f]{64}$/))
       }
     })
   })

--- a/packages/jellyfish-api-core/src/category/blockchain.ts
+++ b/packages/jellyfish-api-core/src/category/blockchain.ts
@@ -165,6 +165,36 @@ export class Blockchain {
   }
 
   /**
+   * Get all in-mempool ancestors for a given transaction as string[]
+   *
+   * @param {string} txId the transaction id
+   * @param {boolean} verbose false
+   * @return {Promise<string[]>}
+   */
+  getMempoolAncestors (txId: string, verbose?: false): Promise<string[]>
+
+  /**
+   * Get all in-mempool ancestors for a given transaction as json object
+   *
+   * @param {string} txId the transaction id
+   * @param {boolean} verbose true
+   * @return {Promise<MempoolTx>}
+   */
+  getMempoolAncestors (txId: string, verbose?: true): Promise<MempoolTx>
+
+  /**
+   * Get all in-mempool ancestors if txId is in mempool as string[] if verbose is false
+   * else as json object
+   *
+   * @param {string} txId the transaction id
+   * @param {boolean} verbose default = false, true for json object, false for array of transaction ids
+   * @return {Promise<string[] | MempoolTx>}
+   */
+  async getMempoolAncestors (txId: string, verbose?: boolean): Promise<string[] | MempoolTx> {
+    return await this.client.call('getmempoolancestors', [txId, verbose], 'bignumber')
+  }
+
+  /**
    * Get mempool data for the given transaction
    * @param {string} txId the transaction id
    * @return {Promise<MempoolTx>}

--- a/packages/jellyfish-api-core/src/category/blockchain.ts
+++ b/packages/jellyfish-api-core/src/category/blockchain.ts
@@ -190,7 +190,7 @@ export class Blockchain {
    * @param {boolean} verbose default = false, true for json object, false for array of transaction ids
    * @return {Promise<string[] | MempoolTx>}
    */
-  async getMempoolAncestors (txId: string, verbose?: boolean): Promise<string[] | MempoolTx> {
+  async getMempoolAncestors (txId: string, verbose: boolean = false): Promise<string[] | MempoolTx> {
     return await this.client.call('getmempoolancestors', [txId, verbose], 'bignumber')
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
/kind feature

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes part of #48 
- Implements `getmempoolancestors` type for RPC.