### PR TITLE
refactor(module.api): poolpair.controller.ts to ignore symbol starting with 'BURN-'

### DIFF
--- a/apps/whale-api/src/module.api/poolpair.controller.ts
+++ b/apps/whale-api/src/module.api/poolpair.controller.ts
@@ -64,7 +64,7 @@ export class PoolPairController {
       return item.id
     })
     response.data = response.data.filter(value => {
-      return value.symbol !== 'BURN-DFI'
+      return !value.symbol.startsWith('BURN-')
     })
     return response
   }


### PR DESCRIPTION
#### What this PR does / why we need it:

As per the title.

