### PR TITLE
feat(jellyfish-api-core): add masternode clearMempool RPC

### DIFF
--- a/docs/node/CATEGORIES/11-masternode.md
+++ b/docs/node/CATEGORIES/11-masternode.md
@@ -269,3 +269,12 @@ interface MasternodeResult<T> {
   [id: string]: T
 }
 ```
+
+## clearMempool
+Clears the memory pool and returns a list of the removed transaction ids.
+
+```ts title="client.masternode.clearMempool"
+interface masternode {
+  clearMempool (): Promise<string[]> 
+}
+```

--- a/packages/jellyfish-api-core/__tests__/category/masternode/clearMempool.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/masternode/clearMempool.test.ts
@@ -1,0 +1,30 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { Testing } from '@defichain/jellyfish-testing'
+
+describe('clear mempool', () => {
+  const container = new MasterNodeRegTestContainer()
+  const testing = Testing.create(container)
+
+  beforeAll(async () => {
+    await testing.container.start()
+    await testing.container.waitForWalletCoinbaseMaturity()
+  })
+
+  afterAll(async () => {
+    await testing.container.stop()
+  })
+
+  it('should clear mempool and return the removed transaction ids', async () => {
+    const createdTxId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.003)
+
+    const txIdsInMempoolBefore = await testing.rpc.blockchain.getRawMempool(false)
+    expect(txIdsInMempoolBefore.length).toBe(1)
+
+    const removedTxIds = await testing.rpc.masternode.clearMempool()
+
+    expect(removedTxIds).toContain(createdTxId)
+
+    const txIdsInMempoolAfter = await testing.rpc.blockchain.getRawMempool(false)
+    expect(txIdsInMempoolAfter.length).toBe(0)
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/masternode/clearMempool.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/masternode/clearMempool.test.ts
@@ -18,13 +18,13 @@ describe('clear mempool', () => {
     const createdTxId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.003)
 
     const txIdsInMempoolBefore = await testing.rpc.blockchain.getRawMempool(false)
-    expect(txIdsInMempoolBefore.length).toBe(1)
+    expect(txIdsInMempoolBefore.length).toStrictEqual(1)
 
     const removedTxIds = await testing.rpc.masternode.clearMempool()
 
     expect(removedTxIds).toContain(createdTxId)
 
     const txIdsInMempoolAfter = await testing.rpc.blockchain.getRawMempool(false)
-    expect(txIdsInMempoolAfter.length).toBe(0)
+    expect(txIdsInMempoolAfter.length).toStrictEqual(0)
   })
 })

--- a/packages/jellyfish-api-core/src/category/masternode.ts
+++ b/packages/jellyfish-api-core/src/category/masternode.ts
@@ -240,6 +240,14 @@ export class Masternode {
   async listAnchors (): Promise<MasternodeResult<MasternodeAnchor>> {
     return await this.client.call('listanchors', [], 'number')
   }
+
+  /**
+   * Clears the memory pool and returns a list of the removed transaction ids.
+   * @return {Promise<string[]>} Array of removed transaction ids
+   */
+  async clearMempool (): Promise<string[]> {
+    return await this.client.call('clearmempool', [], 'number')
+  }
 }
 
 export interface UTXO {


### PR DESCRIPTION
What this PR does / why we need it:
/kind feature

Which issue(s) does this PR fixes?:
Fixes part of https://github.com/JellyfishSDK/jellyfish/issues/48

- Implements `clearmempool` type for RPC.