### PR TITLE
chore(docker): bump to use HEAD-49fba65ce from https://github.com/DeFiCh/ain/pull/1515

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -259,6 +259,7 @@
       <w>tenyeartimelock</w>
       <w>testcontainers</w>
       <w>testmempoolaccept</w>
+      <w>testpoolswap</w>
       <w>thedoublejay</w>
       <w>timelock</w>
       <w>toaltstack</w>

--- a/apps/rich-list-api/docker-compose.yml
+++ b/apps/rich-list-api/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       POSTGRES_DB: defichainrichlist
 
   defi-blockchain:
-    image: defi/defichain:HEAD-02ef6a1b3
+    image: defi/defichain:HEAD-aaaec97e8
     ports:
       - "19554:19554"
     command: >

--- a/apps/rich-list-api/docker-compose.yml
+++ b/apps/rich-list-api/docker-compose.yml
@@ -47,3 +47,4 @@ services:
       -fortcanningspringheight=13
       -fortcanninggreatworldheight=14
       -fortcanningepilogueheight=15
+      -regtest-skip-loan-collateral-validation

--- a/apps/rich-list-api/docker-compose.yml
+++ b/apps/rich-list-api/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       POSTGRES_DB: defichainrichlist
 
   defi-blockchain:
-    image: defi/defichain:HEAD-aaaec97e8
+    image: defi/defichain:HEAD-49fba65ce
     ports:
       - "19554:19554"
     command: >

--- a/apps/whale-api/docker-compose.yml
+++ b/apps/whale-api/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   defi-blockchain:
-    image: defi/defichain:HEAD-aaaec97e8
+    image: defi/defichain:HEAD-49fba65ce
     ports:
       - "19554:19554"
     command: >

--- a/apps/whale-api/docker-compose.yml
+++ b/apps/whale-api/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       -fortcanningspringheight=13
       -fortcanninggreatworldheight=14
       -fortcanningepilogueheight=15
+      -regtest-skip-loan-collateral-validation
 
   defi-whale:
     build:

--- a/apps/whale-api/docker-compose.yml
+++ b/apps/whale-api/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   defi-blockchain:
-    image: defi/defichain:HEAD-02ef6a1b3
+    image: defi/defichain:HEAD-aaaec97e8
     ports:
       - "19554:19554"
     command: >

--- a/packages/jellyfish-api-core/__tests__/category/mining/getMiningInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/mining/getMiningInfo.test.ts
@@ -39,6 +39,6 @@ describe('Mining', () => {
     expect(info.networkhashps).toBeGreaterThan(0)
     expect(info.pooledtx).toStrictEqual(0)
     expect(info.chain).toStrictEqual('regtest')
-    expect(info.warnings).toStrictEqual('This is a pre-release test build - use at your own risk - do not use for mining or merchant applications')
+    expect(info.warnings).toStrictEqual('')
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/poolpair/testpoolswap.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/poolpair/testpoolswap.test.ts
@@ -125,7 +125,13 @@ describe('Poolpair', () => {
       maxPrice: 0.4
     })
     await expect(promise).rejects.toThrow(RpcApiError)
-    await expect(promise).rejects.toThrow('Price is higher than indicated')
+    await expect(promise).rejects.toMatchObject({
+      payload: {
+        code: -32600,
+        message: 'Cannot find usable pool pair. Details: Price is higher than indicated.',
+        method: 'testpoolswap'
+      }
+    })
   })
 
   it('testpoolswap should not affect the ori poolpair data', async () => {
@@ -175,6 +181,12 @@ describe('Poolpair', () => {
       tokenTo: 'DFI'
     })
     await expect(promise).rejects.toThrow(RpcApiError)
-    await expect(promise).rejects.toThrow('Lack of liquidity')
+    await expect(promise).rejects.toMatchObject({
+      payload: {
+        code: -32600,
+        message: 'Cannot find usable pool pair. Details: Lack of liquidity.',
+        method: 'testpoolswap'
+      }
+    })
   })
 })

--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -35,7 +35,7 @@ export abstract class DeFiDContainer extends DockerContainer {
     if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
       return process.env.DEFICHAIN_DOCKER_IMAGE
     }
-    return 'defi/defichain:HEAD-02ef6a1b3'
+    return 'defi/defichain:HEAD-aaaec97e8'
   }
 
   public static readonly DefaultStartOptions = {

--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -35,7 +35,7 @@ export abstract class DeFiDContainer extends DockerContainer {
     if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
       return process.env.DEFICHAIN_DOCKER_IMAGE
     }
-    return 'defi/defichain:HEAD-aaaec97e8'
+    return 'defi/defichain:HEAD-49fba65ce'
   }
 
   public static readonly DefaultStartOptions = {

--- a/packages/testcontainers/src/containers/RegTestContainer/index.ts
+++ b/packages/testcontainers/src/containers/RegTestContainer/index.ts
@@ -39,7 +39,8 @@ export class RegTestContainer extends DeFiDContainer {
       '-fortcanningcrunchheight=12',
       '-fortcanningspringheight=13',
       '-fortcanninggreatworldheight=14',
-      '-fortcanningepilogueheight=15'
+      '-fortcanningepilogueheight=15',
+      '-regtest-skip-loan-collateral-validation'
     ]
 
     if (opts.startFlags != null && opts.startFlags.length > 0) {


### PR DESCRIPTION
#### What this PR does / why we need it:

As per the title.

Bump to use HEAD-49fba65ce from https://github.com/DeFiCh/ain/pull/1515 to address issue from https://github.com/DeFiCh/ain/pull/1509
