### PR TITLE
feat(jellyfish-api-core): add net getNetTotals RPC

### DIFF
--- a/docs/node/CATEGORIES/03-net.md
+++ b/docs/node/CATEGORIES/03-net.md
@@ -69,6 +69,32 @@ export interface PeerInfo {
 }
 ```
 
+## getNetTotals
+
+Returns information about network traffic, including bytes in, bytes out, and current time.
+
+```ts title="client.net.getNetTotals()"
+interface net {
+  getNetTotals (): Promise<NetTotals>
+}
+
+interface NetTotals {
+  totalbytesrecv: number
+  totalbytessent: number
+  timemillis: number
+  uploadtarget: UploadTarget
+}
+
+interface UploadTarget {
+  timeframe: number
+  target: number
+  target_reached: boolean
+  serve_historical_blocks: boolean
+  bytes_left_in_cycle: number
+  time_left_in_cycle: number
+}
+```
+
 ## getNetworkInfo
 
 Returns an object containing various state info regarding P2P networking.

--- a/packages/jellyfish-api-core/__tests__/category/net/getNetTotals.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/net/getNetTotals.test.ts
@@ -39,6 +39,7 @@ describe('Network on masternode', () => {
 
   beforeAll(async () => {
     await container.start()
+    await container.generate(1)
   })
 
   afterAll(async () => {

--- a/packages/jellyfish-api-core/__tests__/category/net/getNetTotals.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/net/getNetTotals.test.ts
@@ -21,16 +21,14 @@ describe('Network without masternode', () => {
       totalbytesrecv: expect.any(Number),
       totalbytessent: expect.any(Number),
       timemillis: expect.any(Number),
-      uploadtarget: expect.any(Object)
-    })
-
-    expect(info.uploadtarget).toStrictEqual({
-      timeframe: expect.any(Number),
-      target: expect.any(Number),
-      target_reached: expect.any(Boolean),
-      serve_historical_blocks: expect.any(Boolean),
-      bytes_left_in_cycle: expect.any(Number),
-      time_left_in_cycle: expect.any(Number)
+      uploadtarget: {
+        timeframe: expect.any(Number),
+        target: expect.any(Number),
+        target_reached: expect.any(Boolean),
+        serve_historical_blocks: expect.any(Boolean),
+        bytes_left_in_cycle: expect.any(Number),
+        time_left_in_cycle: expect.any(Number)
+      }
     })
   })
 })
@@ -54,16 +52,14 @@ describe('Network on masternode', () => {
       totalbytesrecv: expect.any(Number),
       totalbytessent: expect.any(Number),
       timemillis: expect.any(Number),
-      uploadtarget: expect.any(Object)
-    })
-
-    expect(info.uploadtarget).toStrictEqual({
-      timeframe: expect.any(Number),
-      target: expect.any(Number),
-      target_reached: expect.any(Boolean),
-      serve_historical_blocks: expect.any(Boolean),
-      bytes_left_in_cycle: expect.any(Number),
-      time_left_in_cycle: expect.any(Number)
+      uploadtarget: {
+        timeframe: expect.any(Number),
+        target: expect.any(Number),
+        target_reached: expect.any(Boolean),
+        serve_historical_blocks: expect.any(Boolean),
+        bytes_left_in_cycle: expect.any(Number),
+        time_left_in_cycle: expect.any(Number)
+      }
     })
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/net/getNetTotals.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/net/getNetTotals.test.ts
@@ -1,20 +1,54 @@
-import { TestingGroup } from '@defichain/jellyfish-testing'
+import { MasterNodeRegTestContainer, RegTestContainer } from '@defichain/testcontainers/dist/index'
 import { net } from '../../../src'
+import { ContainerAdapterClient } from '../../container_adapter_client'
 
 describe('Network without masternode', () => {
-  const tgroup = TestingGroup.create(2)
-  const { rpc: { net } } = tgroup.get(0)
+  const container = new RegTestContainer()
+  const client = new ContainerAdapterClient(container)
 
   beforeAll(async () => {
-    await tgroup.start()
+    await container.start()
   })
 
   afterAll(async () => {
-    await tgroup.stop()
+    await container.stop()
   })
 
   it('should getNetTotals', async () => {
-    const info: net.NetTotals = await net.getNetTotals()
+    const info: net.NetTotals = await client.net.getNetTotals()
+
+    expect(info).toStrictEqual({
+      totalbytesrecv: expect.any(Number),
+      totalbytessent: expect.any(Number),
+      timemillis: expect.any(Number),
+      uploadtarget: expect.any(Object)
+    })
+
+    expect(info.uploadtarget).toStrictEqual({
+      timeframe: expect.any(Number),
+      target: expect.any(Number),
+      target_reached: expect.any(Boolean),
+      serve_historical_blocks: expect.any(Boolean),
+      bytes_left_in_cycle: expect.any(Number),
+      time_left_in_cycle: expect.any(Number)
+    })
+  })
+})
+
+describe('Network on masternode', () => {
+  const container = new MasterNodeRegTestContainer()
+  const client = new ContainerAdapterClient(container)
+
+  beforeAll(async () => {
+    await container.start()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should getNetTotals', async () => {
+    const info: net.NetTotals = await client.net.getNetTotals()
 
     expect(info).toStrictEqual({
       totalbytesrecv: expect.any(Number),

--- a/packages/jellyfish-api-core/__tests__/category/net/getNetTotals.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/net/getNetTotals.test.ts
@@ -1,0 +1,35 @@
+import { TestingGroup } from '@defichain/jellyfish-testing'
+import { net } from '../../../src'
+
+describe('Network without masternode', () => {
+  const tgroup = TestingGroup.create(2)
+  const { rpc: { net } } = tgroup.get(0)
+
+  beforeAll(async () => {
+    await tgroup.start()
+  })
+
+  afterAll(async () => {
+    await tgroup.stop()
+  })
+
+  it('should getNetTotals', async () => {
+    const info: net.NetTotals = await net.getNetTotals()
+
+    expect(info).toStrictEqual({
+      totalbytesrecv: expect.any(Number),
+      totalbytessent: expect.any(Number),
+      timemillis: expect.any(Number),
+      uploadtarget: expect.any(Object)
+    })
+
+    expect(info.uploadtarget).toStrictEqual({
+      timeframe: expect.any(Number),
+      target: expect.any(Number),
+      target_reached: expect.any(Boolean),
+      serve_historical_blocks: expect.any(Boolean),
+      bytes_left_in_cycle: expect.any(Number),
+      time_left_in_cycle: expect.any(Number)
+    })
+  })
+})

--- a/packages/jellyfish-api-core/src/category/net.ts
+++ b/packages/jellyfish-api-core/src/category/net.ts
@@ -29,6 +29,15 @@ export class Net {
   }
 
   /**
+   * Returns information about network traffic, including bytes in, bytes out, and current time.
+   *
+   * @return {Promise<NetTotals>}
+   */
+  async getNetTotals (): Promise<NetTotals> {
+    return await this.client.call('getnettotals', [], 'number')
+  }
+
+  /**
    * Returns an object containing various state info regarding P2P networking.
    *
    * @return {Promise<NetworkInfo>}
@@ -112,4 +121,20 @@ export interface LocalAddress {
   address: string
   port: number
   score: number
+}
+
+export interface NetTotals {
+  totalbytesrecv: number
+  totalbytessent: number
+  timemillis: number
+  uploadtarget: UploadTarget
+}
+
+export interface UploadTarget {
+  timeframe: number
+  target: number
+  target_reached: boolean
+  serve_historical_blocks: boolean
+  bytes_left_in_cycle: number
+  time_left_in_cycle: number
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
/kind feature

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes part of #48 
- Implements `getnettotals` type for RPC.
