### PR TITLE
feat(whale-api): exclude `csETH` on wrapped tokens

### DIFF
--- a/apps/whale-api/src/module.api/token.controller.spec.ts
+++ b/apps/whale-api/src/module.api/token.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing'
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
-import { TokenController } from './token.controller'
+import { parseDATSymbol, TokenController } from './token.controller'
 import { createPoolPair, createToken } from '@defichain/testing'
 import { NotFoundException, CacheModule } from '@nestjs/common'
 import { DeFiDCache } from './cache/defid.cache'
@@ -306,5 +306,16 @@ describe('get', () => {
         error: 'Not Found'
       })
     }
+  })
+
+  it('should append token symbols with "d"', () => {
+    expect(parseDATSymbol('BTC')).toStrictEqual('dBTC')
+    expect(parseDATSymbol('ETH')).toStrictEqual('dETH')
+  })
+
+  it('should not append selected token symbols with "d"', () => {
+    ['DUSD', 'DFI', 'csETH'].forEach((symbol) => {
+      expect(parseDATSymbol(symbol)).toStrictEqual(symbol)
+    })
   })
 })

--- a/apps/whale-api/src/module.api/token.controller.ts
+++ b/apps/whale-api/src/module.api/token.controller.ts
@@ -99,7 +99,7 @@ export function parseDisplaySymbol (tokenInfo: TokenInfo): string {
 }
 
 export function parseDATSymbol (symbol: string): string {
-  if (['DUSD', 'DFI'].includes(symbol)) {
+  if (['DUSD', 'DFI', 'csETH'].includes(symbol)) {
     return symbol
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Add `csETH` on tokens that will not have `d` as prefix. Additional tests for `parseDATSymbol`

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
