### PR TITLE
chore(jellyfish-api-core): Change assert order in `getMiningInfo.test.ts` to match other tests

### DIFF
--- a/packages/jellyfish-api-core/__tests__/category/mining/getMiningInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/mining/getMiningInfo.test.ts
@@ -39,6 +39,6 @@ describe('Mining', () => {
     expect(info.networkhashps).toBeGreaterThan(0)
     expect(info.pooledtx).toStrictEqual(0)
     expect(info.chain).toStrictEqual('regtest')
-    expect(['', 'This is a pre-release test build - use at your own risk - do not use for mining or merchant applications']).toContain(info.warnings)
+    expect(info.warnings).toMatch(/^This is a pre-release test build - use at your own risk - do not use for mining or merchant applications+$|^$/)
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Uses to the assertion order used by all other tests. Uses a regex pattern to match instead of `toContain`.

#### Additional comments?:

As requested in https://github.com/JellyfishSDK/jellyfish/pull/1841#discussion_r1028115217