### PR TITLE
chore(v3): bump containers to 3.0.0

### DIFF
--- a/apps/rich-list-api/docker-compose.yml
+++ b/apps/rich-list-api/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       POSTGRES_DB: defichainrichlist
 
   defi-blockchain:
-    image: defi/defichain:master-1d169a751
+    image: defi/defichain:3.0.0
     ports:
       - "19554:19554"
     command: >

--- a/apps/whale-api/docker-compose.yml
+++ b/apps/whale-api/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   defi-blockchain:
-    image: defi/defichain:master-1d169a751
+    image: defi/defichain:3.0.0
     ports:
       - "19554:19554"
     command: >

--- a/package-lock.json
+++ b/package-lock.json
@@ -25928,6 +25928,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@defichain/jellyfish-transaction": "^0.0.0",
+        "@defichain/jellyfish-wallet": "^0.0.0",
         "bip32": "^2.0.6",
         "bip39": "^3.0.4",
         "create-hmac": "^1.1.7"
@@ -27890,6 +27892,8 @@
     "@defichain/jellyfish-wallet-mnemonic": {
       "version": "file:packages/jellyfish-wallet-mnemonic",
       "requires": {
+        "@defichain/jellyfish-transaction": "^0.0.0",
+        "@defichain/jellyfish-wallet": "^0.0.0",
         "@types/create-hmac": "1.1.0",
         "bip32": "^2.0.6",
         "bip39": "^3.0.4",
@@ -36044,6 +36048,8 @@
         "@defichain/jellyfish-wallet-mnemonic": {
           "version": "file:packages/jellyfish-wallet-mnemonic",
           "requires": {
+            "@defichain/jellyfish-transaction": "^0.0.0",
+            "@defichain/jellyfish-wallet": "^0.0.0",
             "@types/create-hmac": "1.1.0",
             "bip32": "^2.0.6",
             "bip39": "^3.0.4",

--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -35,7 +35,7 @@ export abstract class DeFiDContainer extends DockerContainer {
     if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
       return process.env.DEFICHAIN_DOCKER_IMAGE
     }
-    return 'defi/defichain:master-1d169a751'
+    return 'defi/defichain:3.0.0'
   }
 
   public static readonly DefaultStartOptions = {


### PR DESCRIPTION
#### What this PR does / why we need it:

As per the title, bump to stable release.
