### PR TITLE
chore(packages/jellyfish-wallet-classic): add `Elliptic.random()` test to WalletClassic test suite

### DIFF
--- a/packages/jellyfish-wallet-classic/__tests__/wallet_classic.test.ts
+++ b/packages/jellyfish-wallet-classic/__tests__/wallet_classic.test.ts
@@ -1,13 +1,14 @@
 import { WIF } from '@defichain/jellyfish-crypto'
 import { BigNumber } from 'bignumber.js'
-import { GenesisKeys } from '@defichain/testcontainers'
+import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
 import { WalletClassic } from '../src'
 
 describe('WalletClassic', () => {
   let wallet: WalletClassic
 
   beforeAll(() => {
-    wallet = new WalletClassic(WIF.asEllipticPair(GenesisKeys[GenesisKeys.length - 1].owner.privKey))
+    const privKey = RegTestFoundationKeys[RegTestFoundationKeys.length - 1].owner.privKey
+    wallet = new WalletClassic(WIF.asEllipticPair(privKey))
   })
 
   it('should get public key', async () => {

--- a/packages/jellyfish-wallet-classic/__tests__/wallet_classic.test.ts
+++ b/packages/jellyfish-wallet-classic/__tests__/wallet_classic.test.ts
@@ -1,6 +1,6 @@
-import { WIF } from '@defichain/jellyfish-crypto'
+import { Bech32, Elliptic, WIF } from '@defichain/jellyfish-crypto'
 import { BigNumber } from 'bignumber.js'
-import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
+import { RegTestFoundationKeys, MainNet } from '@defichain/jellyfish-network'
 import { WalletClassic } from '../src'
 
 describe('WalletClassic', () => {
@@ -45,5 +45,28 @@ describe('WalletClassic', () => {
       tokenId: 0
     }])
     ).rejects.toThrow()
+  })
+})
+
+describe('WalletClassic: Random on MainNet', () => {
+  let wallet: WalletClassic
+
+  beforeAll(() => {
+    wallet = new WalletClassic(Elliptic.random())
+  })
+
+  it('should get bech32 address', async function () {
+    const pubKey = await wallet.publicKey()
+    expect(pubKey.length).toStrictEqual(33)
+
+    const bech32Address = Bech32.fromPubKey(pubKey, MainNet.bech32.hrp)
+    console.log(bech32Address)
+  })
+
+  it('should get WIF', async function () {
+    const privKey = await wallet.privateKey()
+    expect(privKey.length).toStrictEqual(32)
+
+    console.log(WIF.encode(MainNet.wifPrefix, privKey))
   })
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

As per the title, add an example on how to use WalletClassic with `Elliptic.random()`.
