### PR TITLE
chore(apps/whale-api): add 15 seconds timeout to ModelProbeIndicator.liveness

### DIFF
--- a/apps/whale-api/src/module.model/_model.probes.ts
+++ b/apps/whale-api/src/module.model/_model.probes.ts
@@ -19,7 +19,10 @@ export class ModelProbeIndicator extends ProbeIndicator {
    */
   async liveness (): Promise<HealthIndicatorResult> {
     try {
-      await this.block.getHighest()
+      await Promise.race([
+        this.block.getHighest(),
+        new Promise((resolve, reject) => setTimeout(() => reject(new Error('model.timeout')), 15000))
+      ])
     } catch (err) {
       return this.withDead('model', 'unable to get the latest block')
     }


### PR DESCRIPTION
#### What this PR does / why we need it:

As per the title.

Why? Because `this.block.getHighest()` doesn't have a timeout, it can run forever. 
