### PR TITLE
chore(whale-api): optimize UpdateMasternode to run without modifying CreateMasternode

### DIFF
--- a/apps/whale-api/src/module.indexer/model/dftx/create.masternode.spec.ts
+++ b/apps/whale-api/src/module.indexer/model/dftx/create.masternode.spec.ts
@@ -114,11 +114,7 @@ describe('create masternode (pre eunos paya)', () => {
     expect(masternode?.creationHeight).toStrictEqual(masternodeRPCInfo.creationHeight)
     expect(masternode?.resignHeight).toStrictEqual(masternodeRPCInfo.resignHeight)
     expect(masternode?.mintedBlocks).toStrictEqual(masternodeRPCInfo.mintedBlocks)
-    expect(masternode?.updateRecords).toStrictEqual([{
-      height: 103,
-      ownerAddress: masternodeRPCInfo.ownerAuthAddress,
-      operatorAddress: masternodeRPCInfo.operatorAuthAddress
-    }])
+    expect(masternode?.history).toStrictEqual(undefined)
   })
 })
 

--- a/apps/whale-api/src/module.indexer/model/dftx/create.masternode.ts
+++ b/apps/whale-api/src/module.indexer/model/dftx/create.masternode.ts
@@ -30,11 +30,7 @@ export class CreateMasternodeIndexer extends DfTxIndexer<CreateMasternode> {
 
     // This is actually the operatorPubKeyHash but jellyfish deserializes like so
     if (data.operatorPubKeyHash !== undefined) {
-      if (data.operatorType === MasternodeKeyType.PKHashType) {
-        operatorAddress = P2PKH.to(this.network, data.operatorPubKeyHash).utf8String
-      } else { // WitV0KeyHashType
-        operatorAddress = P2WPKH.to(this.network, data.operatorPubKeyHash).utf8String
-      }
+      operatorAddress = CreateMasternodeIndexer.getAddress(this.network, data.operatorType, data.operatorPubKeyHash) ?? ''
     }
 
     await this.masternodeMapper.put({
@@ -92,6 +88,17 @@ export class CreateMasternodeIndexer extends DfTxIndexer<CreateMasternode> {
 
   async invalidateBlockStart (block: RawBlock): Promise<void> {
     await this.masternodeStatsMapper.delete(block.height)
+  }
+
+  public static getAddress (network: NetworkName, type: MasternodeKeyType, addressPubKeyHash: string): string | undefined {
+    if (type === MasternodeKeyType.PKHashType) {
+      return P2PKH.to(network, addressPubKeyHash).utf8String
+    }
+
+    if (type === MasternodeKeyType.WitV0KeyHashType) {
+      return P2WPKH.to(network, addressPubKeyHash).utf8String
+    }
+    return undefined
   }
 }
 

--- a/apps/whale-api/src/module.indexer/model/dftx/create.masternode.ts
+++ b/apps/whale-api/src/module.indexer/model/dftx/create.masternode.ts
@@ -44,7 +44,7 @@ export class CreateMasternodeIndexer extends DfTxIndexer<CreateMasternode> {
       timelock: data.timelock ?? 0,
       block: { hash: block.hash, height: block.height, medianTime: block.mediantime, time: block.time },
       collateral: txn.vout[1].value.toFixed(8),
-      updateRecords: [{ height: block.height, ownerAddress, operatorAddress }]
+      history: [{ txid: txn.txid, ownerAddress, operatorAddress }]
     })
 
     await this.indexStats(block, data, txn.vout[1].value)

--- a/apps/whale-api/src/module.indexer/model/dftx/create.masternode.ts
+++ b/apps/whale-api/src/module.indexer/model/dftx/create.masternode.ts
@@ -43,8 +43,7 @@ export class CreateMasternodeIndexer extends DfTxIndexer<CreateMasternode> {
       mintedBlocks: 0,
       timelock: data.timelock ?? 0,
       block: { hash: block.hash, height: block.height, medianTime: block.mediantime, time: block.time },
-      collateral: txn.vout[1].value.toFixed(8),
-      history: [{ txid: txn.txid, ownerAddress, operatorAddress }]
+      collateral: txn.vout[1].value.toFixed(8)
     })
 
     await this.indexStats(block, data, txn.vout[1].value)

--- a/apps/whale-api/src/module.indexer/model/dftx/update.masternode.spec.ts
+++ b/apps/whale-api/src/module.indexer/model/dftx/update.masternode.spec.ts
@@ -111,14 +111,14 @@ describe('Update masternode', () => {
         time: expect.any(Number)
       },
       collateral: '2.00000000',
-      updateRecords: [
+      history: [
         {
-          height: 193,
+          txid: expect.stringMatching(/[0-9a-f]{64}/),
           ownerAddress: addressDest.utf8String,
           operatorAddress: addressDest.utf8String
         },
         {
-          height: 103,
+          txid: expect.stringMatching(/[0-9a-f]{64}/),
           ownerAddress: ownerAddress,
           operatorAddress: ownerAddress
         }
@@ -192,6 +192,7 @@ describe('invalidate', () => {
     const masternode = await masternodeMapper.get(masternodeId)
 
     expect(masternode).not.toStrictEqual(undefined)
+    expect(masternode?.history?.length).toStrictEqual(0)
 
     const address = await container.getNewAddress('', 'bech32')
     const addressDest: P2WPKH = P2WPKH.fromAddress(RegTest, address, P2WPKH)
@@ -206,7 +207,7 @@ describe('invalidate', () => {
 
     const updateMasternode = await masternodeMapper.get(masternodeId)
     expect(updateMasternode?.operatorAddress).toStrictEqual(addressDestHex)
-    expect(updateMasternode?.updateRecords?.length).toStrictEqual(2)
+    expect(updateMasternode?.history?.length).toStrictEqual(2)
 
     await invalidateFromHeight(app, container, updateHeight)
     await container.generate(2)
@@ -219,7 +220,7 @@ describe('invalidate', () => {
 
       expect(invalidatedMasternode?.ownerAddress).toStrictEqual(initialAddressDestHex)
       expect(invalidatedMasternode?.operatorAddress).toStrictEqual(initialAddressDestHex)
-      expect(invalidatedMasternode?.updateRecords?.length).toStrictEqual(1)
+      expect(invalidatedMasternode?.history?.length).toStrictEqual(1)
     }
   })
 })

--- a/apps/whale-api/src/module.indexer/model/dftx/update.masternode.ts
+++ b/apps/whale-api/src/module.indexer/model/dftx/update.masternode.ts
@@ -56,7 +56,7 @@ export class UpdateMasternodeIndexer extends DfTxIndexer<UpdateMasternode> {
         ...masternode,
         ownerAddress: history[1].ownerAddress ?? masternode.ownerAddress,
         operatorAddress: history[1].operatorAddress ?? masternode.operatorAddress,
-        history: history.slice(0, 1)
+        history: history.slice(1)
       })
     }
   }

--- a/apps/whale-api/src/module.model/masternode.ts
+++ b/apps/whale-api/src/module.model/masternode.ts
@@ -61,8 +61,8 @@ export interface Masternode extends Model {
     medianTime: number
   }
 
-  updateRecords?: Array<{
-    height: number
+  history?: Array<{
+    txid: string
     ownerAddress: string
     operatorAddress: string
   }>


### PR DESCRIPTION
#### What this PR does / why we need it:

This utilizes the "forward indexing" design; it doesn't require `whale-api` to be reindexed. It will automatically create a history entry to `MasternodeMapper`.  You can update your `whale-api` node without this change. 