### PR TITLE
feat(jellyfish-api-core): add loadWallet RPC

### DIFF
--- a/packages/jellyfish-api-core/src/category/wallet.ts
+++ b/packages/jellyfish-api-core/src/category/wallet.ts
@@ -324,6 +324,16 @@ export class Wallet {
   async listWallets (): Promise<string[]> {
     return await this.client.call('listwallets', [], 'number')
   }
+
+  /**
+   * Loads a wallet from a wallet file or directory.
+   *
+   * @param {string} fileName The wallet directory or .dat file
+   * @return {Promise<LoadWalletResult>}
+   */
+  async loadWallet (fileName: string): Promise<LoadWalletResult> {
+    return await this.client.call('loadwallet', [fileName], 'number')
+  }
 }
 
 export interface UTXO {
@@ -508,4 +518,9 @@ export interface WalletWatchOnlyBalances {
   trusted: BigNumber
   untrusted_pending: BigNumber
   immature: BigNumber
+}
+
+export interface LoadWalletResult {
+  walletname: string
+  warning: string
 }


### PR DESCRIPTION
**What this PR does / why we need it:**
/kind feature

**Which issue(s) does this PR fixes?:**
Adds `loadWallet()` from [Issue#48](https://github.com/JellyfishSDK/jellyfish/issues/48)

This feature requires a file path to load a wallet. It should return a wallet name if a .dat file (which stores a wallet) is detected; and returns a warning if the specified file path does not contain a `.dat` file.