### PR TITLE
feat(jellyfish-api-core): add signMessage RPC

### DIFF
--- a/docs/node/CATEGORIES/05-wallet.md
+++ b/docs/node/CATEGORIES/05-wallet.md
@@ -397,3 +397,13 @@ interface wallet {
   listWallets (): Promise<string[]>
 }
 ```
+
+## signMessage
+
+Sign a message with the private key of an address. Requires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.
+
+```ts title="client.wallet.signMessage()"
+interface wallet {
+  signMessage (address: string, message: string): Promise<string>
+}
+```

--- a/docs/node/CATEGORIES/05-wallet.md
+++ b/docs/node/CATEGORIES/05-wallet.md
@@ -400,7 +400,7 @@ interface wallet {
 
 ## signMessage
 
-Sign a message with the private key of an address. Requires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.
+Sign a message with the private key of an address. Requires wallet to be unlocked for usage. Use `walletpassphrase` to unlock wallet.
 
 ```ts title="client.wallet.signMessage()"
 interface wallet {

--- a/packages/jellyfish-api-core/__tests__/category/wallet/signMessage.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/signMessage.test.ts
@@ -1,0 +1,41 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { ContainerAdapterClient } from '../../container_adapter_client'
+import { RpcApiError } from '@defichain/jellyfish-api-core'
+
+describe('Sign Message', () => {
+  const container = new MasterNodeRegTestContainer()
+  const client = new ContainerAdapterClient(container)
+
+  beforeAll(async () => {
+    await container.start()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should throw error if private key is not available', async () => {
+    const promise = client.wallet.signMessage('mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB', 'This is a test message')
+
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toMatchObject({
+      payload: {
+        code: -4,
+        message: 'Private key not available',
+        method: 'signmessage'
+      }
+    })
+  })
+
+  it('should throw error if address is invalid', async () => {
+    const promise = client.wallet.signMessage('test', 'This is a test message')
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toMatchObject({
+      payload: {
+        code: -3,
+        message: 'Invalid address',
+        method: 'signmessage'
+      }
+    })
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/wallet/signMessage.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/signMessage.test.ts
@@ -3,7 +3,7 @@ import { ContainerAdapterClient } from '../../container_adapter_client'
 import { RpcApiError } from '@defichain/jellyfish-api-core'
 import { wallet } from '../../../src'
 
-describe('Sign Message', () => {
+describe('Sign Message on masternode', () => {
   const container = new MasterNodeRegTestContainer()
   const client = new ContainerAdapterClient(container)
 
@@ -59,6 +59,21 @@ describe('Sign Message', () => {
       payload: {
         code: -3,
         message: 'Invalid address',
+        method: 'signmessage'
+      }
+    })
+  })
+
+  it('should throw error if address provided does not contain private key', async () => {
+    const message = 'This is a test message'
+    const address = 'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB'
+    const promise = client.wallet.signMessage(address, message)
+
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toMatchObject({
+      payload: {
+        code: -4,
+        message: 'Private key not available',
         method: 'signmessage'
       }
     })

--- a/packages/jellyfish-api-core/__tests__/category/wallet/signMessage.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/signMessage.test.ts
@@ -1,6 +1,7 @@
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { ContainerAdapterClient } from '../../container_adapter_client'
 import { RpcApiError } from '@defichain/jellyfish-api-core'
+import { wallet } from '../../../src'
 
 describe('Sign Message', () => {
   const container = new MasterNodeRegTestContainer()
@@ -14,21 +15,39 @@ describe('Sign Message', () => {
     await container.stop()
   })
 
-  it('should throw error if private key is not available', async () => {
-    const promise = client.wallet.signMessage('mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB', 'This is a test message')
+  it('should throw error if address provided does not to refer to key (BECH32)', async () => {
+    // getNewAddress generates a BECH32 address by default
+    const address = await client.wallet.getNewAddress()
+    const promise = client.wallet.signMessage(address, 'This is a test message')
 
     await expect(promise).rejects.toThrow(RpcApiError)
     await expect(promise).rejects.toMatchObject({
       payload: {
-        code: -4,
-        message: 'Private key not available',
+        code: -3,
+        message: 'Address does not refer to key',
         method: 'signmessage'
       }
     })
   })
 
-  it('should throw error if address is invalid', async () => {
-    const promise = client.wallet.signMessage('test', 'This is a test message')
+  it('should throw error if address provided does not to refer to key (P2SH)', async () => {
+    const address = await client.wallet.getNewAddress('', wallet.AddressType.P2SH_SEGWIT)
+
+    const promise = client.wallet.signMessage(address, 'This is a test message')
+
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toMatchObject({
+      payload: {
+        code: -3,
+        message: 'Address does not refer to key',
+        method: 'signmessage'
+      }
+    })
+  })
+
+  it('should throw error if invalid address is provided', async () => {
+    const promise = client.wallet.signMessage('', 'This is a test message')
+
     await expect(promise).rejects.toThrow(RpcApiError)
     await expect(promise).rejects.toMatchObject({
       payload: {
@@ -37,5 +56,15 @@ describe('Sign Message', () => {
         method: 'signmessage'
       }
     })
+  })
+
+  it('should be verifiable', async () => {
+    const address = await client.wallet.getNewAddress('', wallet.AddressType.LEGACY)
+    const message = 'This is a test message'
+
+    const signature = await client.wallet.signMessage(address, message)
+
+    const verify = await client.call('verifymessage', [address, signature, 'This is a test message'], 'number')
+    expect(verify).toStrictEqual(true)
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/wallet/signMessage.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/signMessage.test.ts
@@ -15,10 +15,13 @@ describe('Sign Message', () => {
     await container.stop()
   })
 
-  it('should throw error if address provided does not to refer to key (BECH32)', async () => {
-    // getNewAddress generates a BECH32 address by default
+  it('should throw error if BECH32 address is provided', async () => {
+    // getNewAddress() generates a BECH32 address by default
+    // signMessage() is not compatible with BECH32 address
     const address = await client.wallet.getNewAddress()
-    const promise = client.wallet.signMessage(address, 'This is a test message')
+    const message = 'This is a test message'
+
+    const promise = client.wallet.signMessage(address, message)
 
     await expect(promise).rejects.toThrow(RpcApiError)
     await expect(promise).rejects.toMatchObject({
@@ -30,10 +33,12 @@ describe('Sign Message', () => {
     })
   })
 
-  it('should throw error if address provided does not to refer to key (P2SH)', async () => {
+  it('should throw error if P2SH address is provided', async () => {
+    // signMessage() is not compatible with P2SH address
     const address = await client.wallet.getNewAddress('', wallet.AddressType.P2SH_SEGWIT)
+    const message = 'This is a test message'
 
-    const promise = client.wallet.signMessage(address, 'This is a test message')
+    const promise = client.wallet.signMessage(address, message)
 
     await expect(promise).rejects.toThrow(RpcApiError)
     await expect(promise).rejects.toMatchObject({
@@ -45,8 +50,9 @@ describe('Sign Message', () => {
     })
   })
 
-  it('should throw error if invalid address is provided', async () => {
-    const promise = client.wallet.signMessage('', 'This is a test message')
+  it('should throw error if invalid/no address is provided', async () => {
+    const message = 'This is a test message'
+    const promise = client.wallet.signMessage('', message)
 
     await expect(promise).rejects.toThrow(RpcApiError)
     await expect(promise).rejects.toMatchObject({
@@ -58,13 +64,13 @@ describe('Sign Message', () => {
     })
   })
 
-  it('should be verifiable', async () => {
+  it('should be verifiable using verifyMessage()', async () => {
     const address = await client.wallet.getNewAddress('', wallet.AddressType.LEGACY)
     const message = 'This is a test message'
 
     const signature = await client.wallet.signMessage(address, message)
 
-    const verify = await client.call('verifymessage', [address, signature, 'This is a test message'], 'number')
+    const verify = await client.call('verifymessage', [address, signature, message], 'number')
     expect(verify).toStrictEqual(true)
   })
 })

--- a/packages/jellyfish-api-core/src/category/wallet.ts
+++ b/packages/jellyfish-api-core/src/category/wallet.ts
@@ -324,6 +324,18 @@ export class Wallet {
   async listWallets (): Promise<string[]> {
     return await this.client.call('listwallets', [], 'number')
   }
+
+  /**
+   * Sign a message with the private key of an address
+   * Requires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.
+   *
+   * @param {string} address The DeFi address to use for the private key.
+   * @param {string} message The message to create a signature of.
+   * @return {Promise<string>}
+   */
+  async signMessage (address: string, message: string): Promise<string> {
+    return await this.client.call('signmessage', [address, message], 'number')
+  }
 }
 
 export interface UTXO {

--- a/packages/jellyfish-api-core/src/category/wallet.ts
+++ b/packages/jellyfish-api-core/src/category/wallet.ts
@@ -327,7 +327,7 @@ export class Wallet {
 
   /**
    * Sign a message with the private key of an address
-   * Requires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.
+   * Requires wallet to be unlocked for usage. Use `walletpassphrase` to unlock wallet.
    *
    * @param {string} address The DeFi address to use for the private key.
    * @param {string} message The message to create a signature of.


### PR DESCRIPTION
**What this PR does / why we need it:** 
/kind feature

**Which issue(s) does this PR fixes?:** 
Adding `signMessage()` from [Issue#48](https://github.com/JellyfishSDK/jellyfish/issues/48)

This features allow users to sign an arbitrary message using the private key of an address. 
It requires wallet passphrase to be set with `walletpassphrase` call if the wallet is encrypted.

**Additional comments?:**
The primary purpose of `signMessage()` is to present a signature to showcase that the funds are in the control of the private key holder. The holder may also generate a signature with custom prefixes to showcase proof of authorisation.

Usage Example: [Here](https://bitcoin.stackexchange.com/a/3339/160)