### PR TITLE
feat(jellyfish-api-core): add decodeScript RPC

### DIFF
--- a/docs/node/CATEGORIES/04-rawtx.md
+++ b/docs/node/CATEGORIES/04-rawtx.md
@@ -192,3 +192,29 @@ interface ScriptPubKey {
   addresses: string[]
 }
 ```
+## decodeScript
+
+Decode a hex-encoded script.
+
+```ts title="client.rawtx.decodeScript()"
+interface rawtx {
+  decodeScript (hexstring: string): Promise<DecodeScriptResult>
+}
+
+interface decodeScriptResult {
+  asm: string
+  type: string
+  reqSig: number
+  addresses: string[]
+  p2sh: string
+  segwit: segwitResult
+}
+
+interface segwitResult {
+  asm: string
+  hex: string
+  type: string
+  reqSig: number
+  addresses: string[]
+  p2sh-segwit: string
+}

--- a/docs/node/CATEGORIES/04-rawtx.md
+++ b/docs/node/CATEGORIES/04-rawtx.md
@@ -201,20 +201,18 @@ interface rawtx {
   decodeScript (hexstring: string): Promise<DecodeScriptResult>
 }
 
-interface decodeScriptResult {
+interface DecodeScriptResult {
   asm: string
   type: string
-  reqSig: number
+  reqSigs: number
   addresses: string[]
   p2sh: string
-  segwit: segwitResult
-}
-
-interface segwitResult {
-  asm: string
-  hex: string
-  type: string
-  reqSig: number
-  addresses: string[]
-  p2sh-segwit: string
+  segwit: {
+    asm: string
+    hex: string
+    type: string
+    reqSigs: number
+    addresses: string[]
+    p2sh-segwit: string
+    }
 }

--- a/docs/node/CATEGORIES/04-rawtx.md
+++ b/docs/node/CATEGORIES/04-rawtx.md
@@ -192,6 +192,7 @@ interface ScriptPubKey {
   addresses: string[]
 }
 ```
+
 ## decodeScript
 
 Decode a hex-encoded script.
@@ -214,5 +215,5 @@ interface DecodeScriptResult {
     reqSigs: number
     addresses: string[]
     p2sh-segwit: string
-    }
+  }
 }

--- a/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
@@ -1,13 +1,10 @@
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { Testing } from '@defichain/jellyfish-testing'
-import { RpcApiError } from '../../../src'
-import { ContainerAdapterClient } from '../../container_adapter_client'
-import { wallet } from '../../../src'
+import { RpcApiError, wallet } from '../../../src'
 
 describe('Decodescript()', () => {
   const container = new MasterNodeRegTestContainer()
   const testing = Testing.create(container)
-  const client = new ContainerAdapterClient(container)
 
   beforeAll(async () => {
     await container.start()
@@ -38,11 +35,11 @@ describe('Decodescript()', () => {
     })
   })
 
-  it('should decode scriptPubKey from bech32 address', async () => {
+  it('should decode scriptPubKey from BECH32 address', async () => {
     const address = await testing.container.getNewAddress()
     const addressInfo = await testing.rpc.wallet.getAddressInfo(address)
-
     const scriptPk = addressInfo.scriptPubKey
+    
     const decode = await testing.rpc.rawtx.decodeScript(scriptPk)
 
     expect(decode.asm).toStrictEqual(addressInfo.witness_version + ' ' + addressInfo.witness_program)
@@ -54,9 +51,8 @@ describe('Decodescript()', () => {
   it('should decode scriptPubKey from P2SH_SEGWIT address', async () => {
     const address = await testing.container.getNewAddress('', wallet.AddressType.P2SH_SEGWIT)
     const addressInfo = await testing.rpc.wallet.getAddressInfo(address)
-    console.log(addressInfo)
-
     const scriptPk = addressInfo.scriptPubKey
+
     const withoutOpCodes = addressInfo.scriptPubKey.substring(4, 44)
     const decode = await testing.rpc.rawtx.decodeScript(scriptPk)
 
@@ -66,25 +62,48 @@ describe('Decodescript()', () => {
     expect(decode.addresses).toStrictEqual([addressInfo.address])
   })
 
-  it('should decode a null data ', async () => {
-    const nulldata = '48304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
-    const decodeResult = await testing.rpc.rawtx.decodeScript('6a' + nulldata)
-    console.log(decodeResult)
-    //expect(decodeScriptResult.asm).toStrictEqual('OP_RETURN ' + nulldata)
-    // expect(decodeResult.asm).toStrictEqual('nulldata') //need work
-    expect(decodeResult.type).toStrictEqual('nulldata')
-    expect(decodeResult.p2sh).toStrictEqual('2N9YehGXCtVh6nsnkd1ptpoavdSRvod9RAb')
+  it('should decode scriptPubKey from LEGACY address', async () => {
+    const address = 'n2H1Mrobo5PH2grhDa1Kkz6ThYkLmyXLwR'
+    const scriptPk = (await testing.rpc.wallet.getAddressInfo(address)).scriptPubKey
+
+    const decode = await testing.rpc.rawtx.decodeScript(scriptPk)
+
+    expect(decode).toStrictEqual({
+      asm: 'OP_DUP OP_HASH160 e3b7608590327594e40ec1412ec27681086959d9 OP_EQUALVERIFY OP_CHECKSIG',
+      reqSigs: 1,
+      type: 'pubkeyhash',
+      addresses: [ 'n2H1Mrobo5PH2grhDa1Kkz6ThYkLmyXLwR' ],
+      p2sh: '2NC1bsXjkxWvmhp7TNiFgPF3yBRVCrYXzhb',
+      segwit: {
+        asm: '0 e3b7608590327594e40ec1412ec27681086959d9',
+        hex: '0014e3b7608590327594e40ec1412ec27681086959d9',
+        reqSigs: 1,
+        type: 'witness_v0_keyhash',
+        addresses: [ 'bcrt1quwmkppvsxf6efeqwc9qjasnksyyxjkwejd3yaw' ],
+        'p2sh-segwit': '2N2GB1X4scdpHDBgtQxLyLnjL9mrdhpKczw'
+      }
+    })
   })
-  
-  it('should not decode a non-hexadecimal string', async () => {
+
+  it('should flag random data as nulldata', async () => {
+    const random = '48304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
+    const decode = await testing.rpc.rawtx.decodeScript('6a' + random)
+    const withoutOpCodes = random.substring(2)
+
+    expect(decode.asm).toStrictEqual('OP_RETURN ' + withoutOpCodes)
+    expect(decode.type).toStrictEqual('nulldata')
+    expect(decode.p2sh).toStrictEqual('2N9YehGXCtVh6nsnkd1ptpoavdSRvod9RAb')
+  })
+
+  it('should throw error for a non-hexadecimal string', async () => {
     const address = 'text'
     const decode = await testing.rpc.rawtx.decodeScript(address)
-    await expect(decode).rejects.toThrow(RpcApiError)
-  
-    await expect(decode).rejects.toMatchObject({
+    
+    //the following is a WIP
+    expect(decode).toMatchObject({        
       payload: {
         code: -8,
-        // message: 'argument must be hexadecimal string (not \'text\')', //fix message
+        message: "argument must be hexadecimal string (not 'text')", 
         method: 'decodescript'
       }
     })

--- a/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
@@ -14,32 +14,33 @@ describe('Decodescript()', () => {
   })
 
   it('should decode scriptPubKey', async () => {
-    const address = await testing.container.getNewAddress()
-    const addressInfo = await testing.rpc.wallet.getAddressInfo(address)
+  const address = await testing.container.getNewAddress()
+  const addressInfo = await testing.rpc.wallet.getAddressInfo(address)
 
-    const scriptPK = addressInfo.scriptPubKey
-    const decode = await testing.rpc.rawtx.decodeScript(scriptPK)
+  const scriptPK = addressInfo.scriptPubKey
+  const decode = await testing.rpc.rawtx.decodeScript(scriptPK)
 
-    console.log(addressInfo)
-    console.log(scriptPK)
-    console.log(decode) //console log results align expectations
+  //console log results align expectations
+  console.log(addressInfo)
+  console.log(scriptPK)
+  console.log(decode) 
   })
 
 it('should decode a hardcoded P2PK scriptSig correctly', async () => {
-    const signature = '304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
-    const push_signature = '48' + signature
+  const signature = '304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
+  const push = '48' + signature
 
-    const decodeScriptResult = await testing.rpc.rawtx.decodeScript(push_signature)
-    expect(decodeScriptResult.asm).toStrictEqual(signature)
-  })
+  const decodeScriptResult = await testing.rpc.rawtx.decodeScript(push)
+  expect(decodeScriptResult.asm).toStrictEqual(signature)
+})
 
-  it('should decode a hardcoded P2PKH scriptSig correctly', async () => {
-    const signature = '304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
-    const push_signature = '48' + signature
-    const public_key = '03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2'
-    const push_public_key = '21' + public_key
+it('should decode a hardcoded P2PKH scriptSig correctly', async () => {
+  const signature = '304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
+  const pushSig = '48' + signature
+  const pubKey = '03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2'
+  const pushPK = '21' + pubKey
 
-    const decodeScriptResult = await testing.rpc.rawtx.decodeScript(push_signature + push_public_key)
-    expect(decodeScriptResult.asm).toStrictEqual(signature + ' ' + public_key)
+  const decodeScriptResult = await testing.rpc.rawtx.decodeScript(pushSig + pushPK)
+  expect(decodeScriptResult.asm).toStrictEqual(signature + ' ' + pubKey)
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
@@ -83,6 +83,41 @@ describe('Decodescript()', () => {
     })
   })
 
+  it('should decode multisig scriptPubKey', async () => {
+    const pubKey0 = '03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2'
+    const pubKey1 = '03b0da759730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2'
+    const pubKey2 = '03b0da769730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2'
+    const pushPK0 = `21${pubKey0}`
+    const pushPK1 = `21${pubKey1}`
+    const pushPK2 = `21${pubKey2}`
+
+    const script = `52${pushPK0}${pushPK1}${pushPK2}53ae`
+    const decode = await testing.rpc.rawtx.decodeScript(script)
+
+    expect(decode.asm).toStrictEqual(`2 ${pubKey0} ${pubKey1} ${pubKey2} 3 OP_CHECKMULTISIG`)
+    expect(decode).toStrictEqual({
+      asm: '2 03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2 03b0da759730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2 03b0da769730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2 3 OP_CHECKMULTISIG',
+      reqSigs: 2,
+      type: 'multisig',
+      addresses: [
+        'mp52VuXfTKhzYpuR3jLvPEYYUCWt84J7D5',
+        'mrxE8hHPNJPyvvsbYEc2A163WgV2rebvgZ',
+        'n42fKbireJ7NDQzTYKL87xuPrgNuQzwCzt'
+      ],
+      p2sh: '2N1sgbTQxaaTAZwoiLr7wPDEPxoDyo9Jdo9',
+      segwit: {
+        asm: '0 7c70a5d9c2b7341ed8f0379921df2ef1642c6a7302e3286e597af2704395a82a',
+        hex: '00207c70a5d9c2b7341ed8f0379921df2ef1642c6a7302e3286e597af2704395a82a',
+        reqSigs: 1,
+        type: 'witness_v0_scripthash',
+        addresses: [
+          'bcrt1q03c2tkwzku6pak8sx7vjrhew79jzc6nnqt3jsmje0te8qsu44q4qsr7p7t'
+        ],
+        'p2sh-segwit': '2MwkCzzt4QBEZe1YmTZXaR6AjUMyGQZp8WG'
+      }
+    })
+  })
+
   it('should flag random data as nulldata', async () => {
     const random = '48304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
     const decode = await testing.rpc.rawtx.decodeScript(`6a${random}`)

--- a/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
@@ -1,0 +1,40 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { ContainerAdapterClient } from '../../container_adapter_client'
+
+describe('Decodescript', () => {
+  const container = new MasterNodeRegTestContainer()
+  const client = new ContainerAdapterClient(container)
+
+  beforeAll(async () => {
+    await container.start()
+    await container.waitForWalletCoinbaseMaturity()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  async function createToken (symbol: string): Promise<string> {
+    const newAddress = await container.call('getnewaddress')
+    const createTokenMetadata = {
+      symbol,
+      name: symbol,
+      isDAT: true,
+      mintable: true,
+      tradeable: true,
+      collateralAddress: newAddress
+    }
+    const txid = await container.call('createtoken', [createTokenMetadata])
+    await container.generate(1)
+    return txid
+  }
+
+  it('should decode non-standard script', async () => {
+    const txid = await createToken('BOB')
+    const count = await container.call('getblockcount')
+    const hash = await container.call('getblockhash', [count])
+    const hex: string = await client.rawtx.getRawTransaction(txid, false, hash)
+    const decode = await client.rawtx.decodeScript(hex)
+    console.log(decode)
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
@@ -13,6 +13,27 @@ describe('Decodescript()', () => {
     await container.stop()
   })
 
+  it('should allow for empty scripts', async () => {
+    const address = ''
+    const decode = await testing.rpc.rawtx.decodeScript(address)
+    
+    expect(decode).toStrictEqual({
+        asm: '',
+        type: 'nonstandard',
+        p2sh: '2N9hLwkSqr1cPQAPxbrGVUjxyjD11G2e1he',
+        segwit: {
+          asm: '0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+          hex: '0020e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+          reqSigs: 1,
+          type: 'witness_v0_scripthash',
+          addresses: [
+            'bcrt1quwcvgs5clswpfxhm7nyfjmaeysn6us0yvjdexn9yjkv3k7zjhp2snwgpgy'
+          ],
+          'p2sh-segwit': '2N2CmnxjBbPTHrawgG2FkTuBLcJtEzA86sF'
+        }
+    })
+  })
+
   it('should decode scriptPubKey', async () => {
     const address = await testing.container.getNewAddress()
     const addressInfo = await testing.rpc.wallet.getAddressInfo(address)
@@ -20,11 +41,12 @@ describe('Decodescript()', () => {
     const scriptPK = addressInfo.scriptPubKey
     const decode = await testing.rpc.rawtx.decodeScript(scriptPK)
 
-    //console log results align expectations
+    // //console log results align expectations
+
     console.log(addressInfo)
     console.log(scriptPK)
     console.log(decode) 
-    })
+  })
 
   it('should decode a hardcoded P2PK scriptSig correctly', async () => {
     const signature = '304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
@@ -42,5 +64,5 @@ describe('Decodescript()', () => {
 
     const decodeScriptResult = await testing.rpc.rawtx.decodeScript(pushSig + pushPK)
     expect(decodeScriptResult.asm).toStrictEqual(signature + ' ' + pubKey)
-    })
   })
+})

--- a/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
@@ -14,7 +14,7 @@ describe('Decodescript()', () => {
     await container.stop()
   })
 
-  it('should return the following for empty script', async () => {
+  it('should return empty value for empty script', async () => {
     const address = ''
     const decode = await testing.rpc.rawtx.decodeScript(address)
 

--- a/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
@@ -14,7 +14,7 @@ describe('Decodescript()', () => {
     await container.stop()
   })
 
-  it('should decode empty script', async () => {
+  it('should return the following for empty script', async () => {
     const address = ''
     const decode = await testing.rpc.rawtx.decodeScript(address)
 
@@ -41,10 +41,12 @@ describe('Decodescript()', () => {
     const scriptPk = addressInfo.scriptPubKey
     const decode = await testing.rpc.rawtx.decodeScript(scriptPk)
 
-    expect(decode.asm).toStrictEqual(`${addressInfo.witness_version} ${addressInfo.witness_program}`)
-    expect(decode.reqSigs).toStrictEqual(1)
-    expect(decode.type).toStrictEqual('witness_v0_keyhash')
-    expect(decode.addresses).toStrictEqual([addressInfo.address])
+    expect(decode).toStrictEqual(expect.objectContaining({
+      asm: `${addressInfo.witness_version} ${addressInfo.witness_program}`,
+      reqSigs: 1,
+      type: 'witness_v0_keyhash',
+      addresses: [addressInfo.address]
+    }))
   })
 
   it('should decode scriptPubKey from P2SH_SEGWIT address', async () => {
@@ -55,10 +57,12 @@ describe('Decodescript()', () => {
     const withoutOpCodes = addressInfo.scriptPubKey.substring(4, 44)
     const decode = await testing.rpc.rawtx.decodeScript(scriptPk)
 
-    expect(decode.asm).toStrictEqual(`OP_HASH160 ${withoutOpCodes} OP_EQUAL`)
-    expect(decode.reqSigs).toStrictEqual(1)
-    expect(decode.type).toStrictEqual('scripthash')
-    expect(decode.addresses).toStrictEqual([addressInfo.address])
+    expect(decode).toStrictEqual(expect.objectContaining({
+      asm: `OP_HASH160 ${withoutOpCodes} OP_EQUAL`,
+      reqSigs: 1,
+      type: 'scripthash',
+      addresses: [addressInfo.address]
+    }))
   })
 
   it('should decode scriptPubKey from LEGACY address', async () => {
@@ -94,7 +98,6 @@ describe('Decodescript()', () => {
     const script = `52${pushPK0}${pushPK1}${pushPK2}53ae`
     const decode = await testing.rpc.rawtx.decodeScript(script)
 
-    expect(decode.asm).toStrictEqual(`2 ${pubKey0} ${pubKey1} ${pubKey2} 3 OP_CHECKMULTISIG`)
     expect(decode).toStrictEqual({
       asm: '2 03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2 03b0da759730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2 03b0da769730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2 3 OP_CHECKMULTISIG',
       reqSigs: 2,
@@ -123,9 +126,11 @@ describe('Decodescript()', () => {
     const decode = await testing.rpc.rawtx.decodeScript(`6a${random}`)
     const withoutOpCodes = random.substring(2)
 
-    expect(decode.asm).toStrictEqual(`OP_RETURN ${withoutOpCodes}`)
-    expect(decode.type).toStrictEqual('nulldata')
-    expect(decode.p2sh).toStrictEqual('2N9YehGXCtVh6nsnkd1ptpoavdSRvod9RAb')
+    expect(decode).toStrictEqual(expect.objectContaining({
+      asm: `OP_RETURN ${withoutOpCodes}`,
+      type: 'nulldata',
+      p2sh: '2N9YehGXCtVh6nsnkd1ptpoavdSRvod9RAb'
+    }))
   })
 
   it('should throw error for a non-hexadecimal string', async () => {

--- a/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
@@ -1,9 +1,13 @@
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { Testing } from '@defichain/jellyfish-testing'
+import { RpcApiError } from '../../../src'
+import { ContainerAdapterClient } from '../../container_adapter_client'
+import { wallet } from '../../../src'
 
 describe('Decodescript()', () => {
   const container = new MasterNodeRegTestContainer()
   const testing = Testing.create(container)
+  const client = new ContainerAdapterClient(container)
 
   beforeAll(async () => {
     await container.start()
@@ -13,56 +17,76 @@ describe('Decodescript()', () => {
     await container.stop()
   })
 
-  it('should allow for empty scripts', async () => {
+  it('should decode empty script', async () => {
     const address = ''
     const decode = await testing.rpc.rawtx.decodeScript(address)
     
     expect(decode).toStrictEqual({
-        asm: '',
-        type: 'nonstandard',
-        p2sh: '2N9hLwkSqr1cPQAPxbrGVUjxyjD11G2e1he',
-        segwit: {
-          asm: '0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-          hex: '0020e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-          reqSigs: 1,
-          type: 'witness_v0_scripthash',
-          addresses: [
-            'bcrt1quwcvgs5clswpfxhm7nyfjmaeysn6us0yvjdexn9yjkv3k7zjhp2snwgpgy'
-          ],
-          'p2sh-segwit': '2N2CmnxjBbPTHrawgG2FkTuBLcJtEzA86sF'
-        }
+      asm: '',
+      type: 'nonstandard',
+      p2sh: '2N9hLwkSqr1cPQAPxbrGVUjxyjD11G2e1he',
+      segwit: {
+        asm: '0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+        hex: '0020e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+        reqSigs: 1,
+        type: 'witness_v0_scripthash',
+        addresses: [
+          'bcrt1quwcvgs5clswpfxhm7nyfjmaeysn6us0yvjdexn9yjkv3k7zjhp2snwgpgy'
+        ],
+        'p2sh-segwit': '2N2CmnxjBbPTHrawgG2FkTuBLcJtEzA86sF'
+      }
     })
   })
 
-  it('should decode scriptPubKey', async () => {
+  it('should decode scriptPubKey from bech32 address', async () => {
     const address = await testing.container.getNewAddress()
     const addressInfo = await testing.rpc.wallet.getAddressInfo(address)
 
-    const scriptPK = addressInfo.scriptPubKey
-    const decode = await testing.rpc.rawtx.decodeScript(scriptPK)
+    const scriptPk = addressInfo.scriptPubKey
+    const decode = await testing.rpc.rawtx.decodeScript(scriptPk)
 
-    // //console log results align expectations
+    expect(decode.asm).toStrictEqual(addressInfo.witness_version + ' ' + addressInfo.witness_program)
+    expect(decode.reqSigs).toStrictEqual(1)
+    expect(decode.type).toStrictEqual('witness_v0_keyhash')
+    expect(decode.addresses).toStrictEqual([addressInfo.address])
+  })
 
+  it('should decode scriptPubKey from P2SH_SEGWIT address', async () => {
+    const address = await testing.container.getNewAddress('', wallet.AddressType.P2SH_SEGWIT)
+    const addressInfo = await testing.rpc.wallet.getAddressInfo(address)
     console.log(addressInfo)
-    console.log(scriptPK)
-    console.log(decode) 
+
+    const scriptPk = addressInfo.scriptPubKey
+    const withoutOpCodes = addressInfo.scriptPubKey.substring(4, 44)
+    const decode = await testing.rpc.rawtx.decodeScript(scriptPk)
+
+    expect(decode.asm).toStrictEqual('OP_HASH160 ' + withoutOpCodes + ' OP_EQUAL')
+    expect(decode.reqSigs).toStrictEqual(1)
+    expect(decode.type).toStrictEqual('scripthash')
+    expect(decode.addresses).toStrictEqual([addressInfo.address])
   })
 
-  it('should decode a hardcoded P2PK scriptSig correctly', async () => {
-    const signature = '304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
-    const push = '48' + signature
-
-    const decodeScriptResult = await testing.rpc.rawtx.decodeScript(push)
-    expect(decodeScriptResult.asm).toStrictEqual(signature)
+  it('should decode a null data ', async () => {
+    const nulldata = '48304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
+    const decodeResult = await testing.rpc.rawtx.decodeScript('6a' + nulldata)
+    console.log(decodeResult)
+    //expect(decodeScriptResult.asm).toStrictEqual('OP_RETURN ' + nulldata)
+    // expect(decodeResult.asm).toStrictEqual('nulldata') //need work
+    expect(decodeResult.type).toStrictEqual('nulldata')
+    expect(decodeResult.p2sh).toStrictEqual('2N9YehGXCtVh6nsnkd1ptpoavdSRvod9RAb')
   })
-
-  it('should decode a hardcoded P2PKH scriptSig correctly', async () => {
-    const signature = '304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
-    const pushSig = '48' + signature
-    const pubKey = '03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2'
-    const pushPK = '21' + pubKey
-
-    const decodeScriptResult = await testing.rpc.rawtx.decodeScript(pushSig + pushPK)
-    expect(decodeScriptResult.asm).toStrictEqual(signature + ' ' + pubKey)
+  
+  it('should not decode a non-hexadecimal string', async () => {
+    const address = 'text'
+    const decode = await testing.rpc.rawtx.decodeScript(address)
+    await expect(decode).rejects.toThrow(RpcApiError)
+  
+    await expect(decode).rejects.toMatchObject({
+      payload: {
+        code: -8,
+        // message: 'argument must be hexadecimal string (not \'text\')', //fix message
+        method: 'decodescript'
+      }
+    })
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
@@ -2,8 +2,8 @@ import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { Testing } from '@defichain/jellyfish-testing'
 
 describe('Decodescript()', () => {
-    const container = new MasterNodeRegTestContainer()
-    const testing = Testing.create(container)
+  const container = new MasterNodeRegTestContainer()
+  const testing = Testing.create(container)
 
   beforeAll(async () => {
     await container.start()
@@ -14,33 +14,33 @@ describe('Decodescript()', () => {
   })
 
   it('should decode scriptPubKey', async () => {
-  const address = await testing.container.getNewAddress()
-  const addressInfo = await testing.rpc.wallet.getAddressInfo(address)
+    const address = await testing.container.getNewAddress()
+    const addressInfo = await testing.rpc.wallet.getAddressInfo(address)
 
-  const scriptPK = addressInfo.scriptPubKey
-  const decode = await testing.rpc.rawtx.decodeScript(scriptPK)
+    const scriptPK = addressInfo.scriptPubKey
+    const decode = await testing.rpc.rawtx.decodeScript(scriptPK)
 
-  //console log results align expectations
-  console.log(addressInfo)
-  console.log(scriptPK)
-  console.log(decode) 
+    //console log results align expectations
+    console.log(addressInfo)
+    console.log(scriptPK)
+    console.log(decode) 
+    })
+
+  it('should decode a hardcoded P2PK scriptSig correctly', async () => {
+    const signature = '304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
+    const push = '48' + signature
+
+    const decodeScriptResult = await testing.rpc.rawtx.decodeScript(push)
+    expect(decodeScriptResult.asm).toStrictEqual(signature)
   })
 
-it('should decode a hardcoded P2PK scriptSig correctly', async () => {
-  const signature = '304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
-  const push = '48' + signature
+  it('should decode a hardcoded P2PKH scriptSig correctly', async () => {
+    const signature = '304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
+    const pushSig = '48' + signature
+    const pubKey = '03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2'
+    const pushPK = '21' + pubKey
 
-  const decodeScriptResult = await testing.rpc.rawtx.decodeScript(push)
-  expect(decodeScriptResult.asm).toStrictEqual(signature)
-})
-
-it('should decode a hardcoded P2PKH scriptSig correctly', async () => {
-  const signature = '304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
-  const pushSig = '48' + signature
-  const pubKey = '03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2'
-  const pushPK = '21' + pubKey
-
-  const decodeScriptResult = await testing.rpc.rawtx.decodeScript(pushSig + pushPK)
-  expect(decodeScriptResult.asm).toStrictEqual(signature + ' ' + pubKey)
+    const decodeScriptResult = await testing.rpc.rawtx.decodeScript(pushSig + pushPK)
+    expect(decodeScriptResult.asm).toStrictEqual(signature + ' ' + pubKey)
+    })
   })
-})

--- a/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/rawtx/decodeScript.test.ts
@@ -1,6 +1,6 @@
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { Testing } from '@defichain/jellyfish-testing'
-import { RpcApiError, wallet } from '../../../src'
+import { wallet } from '../../../src'
 
 describe('Decodescript()', () => {
   const container = new MasterNodeRegTestContainer()
@@ -17,7 +17,7 @@ describe('Decodescript()', () => {
   it('should decode empty script', async () => {
     const address = ''
     const decode = await testing.rpc.rawtx.decodeScript(address)
-    
+
     expect(decode).toStrictEqual({
       asm: '',
       type: 'nonstandard',
@@ -39,10 +39,9 @@ describe('Decodescript()', () => {
     const address = await testing.container.getNewAddress()
     const addressInfo = await testing.rpc.wallet.getAddressInfo(address)
     const scriptPk = addressInfo.scriptPubKey
-    
     const decode = await testing.rpc.rawtx.decodeScript(scriptPk)
 
-    expect(decode.asm).toStrictEqual(addressInfo.witness_version + ' ' + addressInfo.witness_program)
+    expect(decode.asm).toStrictEqual(`${addressInfo.witness_version} ${addressInfo.witness_program}`)
     expect(decode.reqSigs).toStrictEqual(1)
     expect(decode.type).toStrictEqual('witness_v0_keyhash')
     expect(decode.addresses).toStrictEqual([addressInfo.address])
@@ -56,7 +55,7 @@ describe('Decodescript()', () => {
     const withoutOpCodes = addressInfo.scriptPubKey.substring(4, 44)
     const decode = await testing.rpc.rawtx.decodeScript(scriptPk)
 
-    expect(decode.asm).toStrictEqual('OP_HASH160 ' + withoutOpCodes + ' OP_EQUAL')
+    expect(decode.asm).toStrictEqual(`OP_HASH160 ${withoutOpCodes} OP_EQUAL`)
     expect(decode.reqSigs).toStrictEqual(1)
     expect(decode.type).toStrictEqual('scripthash')
     expect(decode.addresses).toStrictEqual([addressInfo.address])
@@ -65,21 +64,20 @@ describe('Decodescript()', () => {
   it('should decode scriptPubKey from LEGACY address', async () => {
     const address = 'n2H1Mrobo5PH2grhDa1Kkz6ThYkLmyXLwR'
     const scriptPk = (await testing.rpc.wallet.getAddressInfo(address)).scriptPubKey
-
     const decode = await testing.rpc.rawtx.decodeScript(scriptPk)
 
     expect(decode).toStrictEqual({
       asm: 'OP_DUP OP_HASH160 e3b7608590327594e40ec1412ec27681086959d9 OP_EQUALVERIFY OP_CHECKSIG',
       reqSigs: 1,
       type: 'pubkeyhash',
-      addresses: [ 'n2H1Mrobo5PH2grhDa1Kkz6ThYkLmyXLwR' ],
+      addresses: ['n2H1Mrobo5PH2grhDa1Kkz6ThYkLmyXLwR'],
       p2sh: '2NC1bsXjkxWvmhp7TNiFgPF3yBRVCrYXzhb',
       segwit: {
         asm: '0 e3b7608590327594e40ec1412ec27681086959d9',
         hex: '0014e3b7608590327594e40ec1412ec27681086959d9',
         reqSigs: 1,
         type: 'witness_v0_keyhash',
-        addresses: [ 'bcrt1quwmkppvsxf6efeqwc9qjasnksyyxjkwejd3yaw' ],
+        addresses: ['bcrt1quwmkppvsxf6efeqwc9qjasnksyyxjkwejd3yaw'],
         'p2sh-segwit': '2N2GB1X4scdpHDBgtQxLyLnjL9mrdhpKczw'
       }
     })
@@ -87,25 +85,17 @@ describe('Decodescript()', () => {
 
   it('should flag random data as nulldata', async () => {
     const random = '48304502207fa7a6d1e0ee81132a269ad84e68d695483745cde8b541e3bf630749894e342a022100c1f7ab20e13e22fb95281a870f3dcf38d782e53023ee313d741ad0cfbc0c509001'
-    const decode = await testing.rpc.rawtx.decodeScript('6a' + random)
+    const decode = await testing.rpc.rawtx.decodeScript(`6a${random}`)
     const withoutOpCodes = random.substring(2)
 
-    expect(decode.asm).toStrictEqual('OP_RETURN ' + withoutOpCodes)
+    expect(decode.asm).toStrictEqual(`OP_RETURN ${withoutOpCodes}`)
     expect(decode.type).toStrictEqual('nulldata')
     expect(decode.p2sh).toStrictEqual('2N9YehGXCtVh6nsnkd1ptpoavdSRvod9RAb')
   })
 
   it('should throw error for a non-hexadecimal string', async () => {
     const address = 'text'
-    const decode = await testing.rpc.rawtx.decodeScript(address)
-    
-    //the following is a WIP
-    expect(decode).toMatchObject({        
-      payload: {
-        code: -8,
-        message: "argument must be hexadecimal string (not 'text')", 
-        method: 'decodescript'
-      }
-    })
+    return await expect(testing.rpc.rawtx.decodeScript(address))
+      .rejects.toThrow("RpcApiError: 'argument must be hexadecimal string (not 'text')', code: -8, method: decodescript")
   })
 })

--- a/packages/jellyfish-api-core/src/category/rawtx.ts
+++ b/packages/jellyfish-api-core/src/category/rawtx.ts
@@ -347,53 +347,53 @@ export interface RawTransaction {
 }
 
 export interface DecodeScriptResult {
-  asm: string
   /**
    * Script public key
    */
-  type: string
+  asm: string
   /**
    * The output type
    */
-  reqSigs: number
+  type: string
   /**
    * The required signatures
    */
-  addresses: string[]
+  reqSigs: number
   /**
    * DeFi address
    */
-  p2sh: string
+  addresses: string[]
   /**
    * address of P2SH script wrapping this redeem script (not returned if the script is already a P2SH)
    */
-  segwit: {
+  p2sh: string
   /**
    * Result of a witness script public key wrapping this redeem script (not returned if the script is a P2SH or witness)
    */
-    asm: string
-    /**
+  segwit: {
+  /**
    * String representation of the script public key
    */
-    hex: string
+    asm: string
     /**
    * Hex string of the script public key
    */
-    type: string
+    hex: string
     /**
    * The type of the script public key (e.g. witness_v0_keyhash or witness_v0_scripthash)
    */
-    reqSigs: number
+    type: string
     /**
    * The required signatures (always 1)
    */
-    addresses: string[] // (always length 1)
+    reqSigs: number
     /**
    * segwit address
    */
-    p2shsegwit: string
-  /**
+    addresses: string[] // (always length 1)
+    /**
    * address of the P2SH script wrapping this witness redeem script
    */
+    p2shsegwit: string
   }
 }

--- a/packages/jellyfish-api-core/src/category/rawtx.ts
+++ b/packages/jellyfish-api-core/src/category/rawtx.ts
@@ -371,29 +371,29 @@ export interface DecodeScriptResult {
    * Result of a witness script public key wrapping this redeem script (not returned if the script is a P2SH or witness)
    */
   segwit: {
-  /**
-   * String representation of the script public key
-   */
+    /**
+     * String representation of the script public key
+     */
     asm: string
     /**
-   * Hex string of the script public key
-   */
+     * Hex string of the script public key
+     */
     hex: string
     /**
-   * The type of the script public key (e.g. witness_v0_keyhash or witness_v0_scripthash)
-   */
+     * The type of the script public key (e.g. witness_v0_keyhash or witness_v0_scripthash)
+     */
     type: string
     /**
-   * The required signatures (always 1)
-   */
+     * The required signatures (always 1)
+     */
     reqSigs: number
     /**
-   * segwit address
-   */
+     * segwit address
+     */
     addresses: string[] // (always length 1)
     /**
-   * address of the P2SH script wrapping this witness redeem script
-   */
+     * address of the P2SH script wrapping this witness redeem script
+     */
     p2shsegwit: string
   }
 }

--- a/packages/jellyfish-api-core/src/category/rawtx.ts
+++ b/packages/jellyfish-api-core/src/category/rawtx.ts
@@ -375,23 +375,23 @@ export interface DecodeScriptResult {
    * String representation of the script public key
    */
     asm: string
-  /**
+    /**
    * Hex string of the script public key
    */
     hex: string
-  /**
+    /**
    * The type of the script public key (e.g. witness_v0_keyhash or witness_v0_scripthash)
    */
     type: string
-  /**
+    /**
    * The required signatures (always 1)
    */
     reqSigs: number
-  /**
+    /**
    * segwit address
    */
     addresses: string[] // (always length 1)
-  /**
+    /**
    * address of the P2SH script wrapping this witness redeem script
    */
     p2shsegwit: string

--- a/packages/jellyfish-api-core/src/category/rawtx.ts
+++ b/packages/jellyfish-api-core/src/category/rawtx.ts
@@ -171,6 +171,16 @@ export class RawTx {
   ): Promise<string | RawTransaction> {
     return await this.client.call('getrawtransaction', [txid, verbose, blockHash], 'number')
   }
+
+  /**
+   * Decode a hex-encoded script.
+   *
+   * @param {string} hexstring The hex-encoded script
+   * @return {Promise<DecodeScriptResult>}
+   */
+  async decodeScript (hexstring: string): Promise<DecodeScriptResult> {
+    return await this.client.call('decodescript', [hexstring], 'number')
+  }
 }
 
 export interface CreateRawTxOptions {
@@ -334,4 +344,56 @@ export interface RawTransaction {
    * The block time in seconds since epoch (Jan 1 1970 GMT)
    */
   blocktime: number
+}
+
+export interface DecodeScriptResult {
+  asm: string
+  /**
+   * Script public key
+   */
+  type: string
+  /**
+   * The output type
+   */
+  reqSigs: number
+  /**
+   * The required signatures
+   */
+  addresses: string[]
+  /**
+   * DeFi address
+   */
+  p2sh: string
+  /**
+   * address of P2SH script wrapping this redeem script (not returned if the script is already a P2SH)
+   */
+  segwit: {
+  /**
+   * Result of a witness script public key wrapping this redeem script (not returned if the script is a P2SH or witness)
+   */
+    asm: string
+    /**
+   * String representation of the script public key
+   */
+    hex: string
+    /**
+   * Hex string of the script public key
+   */
+    type: string
+    /**
+   * The type of the script public key (e.g. witness_v0_keyhash or witness_v0_scripthash)
+   */
+    reqSigs: number
+    /**
+   * The required signatures (always 1)
+   */
+    addresses: string[] // (always length 1)
+    /**
+   * segwit address
+   */
+    p2shsegwit: string
+  /**
+   * address of the P2SH script wrapping this witness redeem script
+   */
+  }
 }

--- a/packages/jellyfish-api-core/src/category/rawtx.ts
+++ b/packages/jellyfish-api-core/src/category/rawtx.ts
@@ -375,23 +375,23 @@ export interface DecodeScriptResult {
    * String representation of the script public key
    */
     asm: string
-    /**
+  /**
    * Hex string of the script public key
    */
     hex: string
-    /**
+  /**
    * The type of the script public key (e.g. witness_v0_keyhash or witness_v0_scripthash)
    */
     type: string
-    /**
+  /**
    * The required signatures (always 1)
    */
     reqSigs: number
-    /**
+  /**
    * segwit address
    */
     addresses: string[] // (always length 1)
-    /**
+  /**
    * address of the P2SH script wrapping this witness redeem script
    */
     p2shsegwit: string


### PR DESCRIPTION
**What this PR does / why we need it:**
/kind feature

**Which issue(s) does this PR fixes?:**
decodeScript() from [Issue#48](https://github.com/JellyfishSDK/jellyfish/issues/48) 

This feature allows the decoding of a hex-encoded script.

**Additional comments?:**
References and good-to-knows [#1](https://bitcoin.stackexchange.com/questions/95725/decodescript-for-a-testnet-pubkey-hash-address/95729#95729), [#2](https://bitcoin.stackexchange.com/questions/64610/what-is-type-pubkey-in-a-scriptpubkey-output-from-getrawtransaction/64612#64612), [#3](https://bitcoin.stackexchange.com/questions/57217/verifying-a-p2sh-transaction-script-by-hand-how-should-i-concatenate-op-codes-i/57220#57220), [#4](https://bitcoin.stackexchange.com/questions/85675/how-to-disassemble-a-bitcoin-script/85679#85679).