### PR TITLE
feat(apps/whale-api): always return the highest yield

### DIFF
--- a/apps/whale-api/src/module.api/poolpair.controller.e2e.ts
+++ b/apps/whale-api/src/module.api/poolpair.controller.e2e.ts
@@ -512,38 +512,6 @@ describe('get best path', () => {
     })
   })
 
-  it('should return direct path even if composite swap paths has greater return', async () => {
-    // 1 J = 7 K
-    // 1 J = 2 L = 8 K
-    const response = await controller.getBestPath('10', '11')
-    expect(response).toStrictEqual({
-      fromToken: {
-        id: '10',
-        name: 'J',
-        symbol: 'J',
-        displaySymbol: 'dJ'
-      },
-      toToken: {
-        id: '11',
-        name: 'K',
-        symbol: 'K',
-        displaySymbol: 'dK'
-      },
-      bestPath: [
-        {
-          symbol: 'J-K',
-          poolPairId: '23',
-          priceRatio: { ab: '0.14285714', ba: '7.00000000' },
-          tokenA: { id: '10', name: 'J', symbol: 'J', displaySymbol: 'dJ' },
-          tokenB: { id: '11', name: 'K', symbol: 'K', displaySymbol: 'dK' },
-          commissionFeeInPct: '0.25000000'
-        }
-      ],
-      estimatedReturn: '7.00000000',
-      estimatedReturnLessDexFees: '5.25000000'
-    })
-  })
-
   it('should deduct commission fee - 1 leg', async () => {
     const response = await controller.getBestPath('10', '12')
     expect(response).toStrictEqual({

--- a/apps/whale-api/src/module.api/poolswap.pathfinding.service.ts
+++ b/apps/whale-api/src/module.api/poolswap.pathfinding.service.ts
@@ -52,20 +52,6 @@ export class PoolSwapPathFindingService {
       paths
     } = await this.getAllSwapPaths(fromTokenId, toTokenId)
 
-    // always use direct path if available
-    for (const path of paths) {
-      const { estimatedReturn, estimatedReturnLessDexFees } = computeReturnLessDexFeesInDestinationToken(path, fromTokenId)
-      if (path.length === 1) {
-        return {
-          fromToken: fromToken,
-          toToken: toToken,
-          bestPath: path,
-          estimatedReturn: formatNumber(estimatedReturn), // denoted in toToken
-          estimatedReturnLessDexFees: formatNumber(estimatedReturnLessDexFees) // denoted in toToken
-        }
-      }
-    }
-
     // otherwise, search for the best path based on return
     let bestPath: SwapPathPoolPair[] = []
     let bestReturnLessDexFees = new BigNumber(0)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Initially, the behavior is always to return the highest yield when doing swaps. We have updated it to use direct path first (if available) before considering other options. Even if direct path is more expensive. 

This will revert it to its original behavior as some pairs are cheaper via composite swaps. (e.g, DFI -> DUSD). Will fix this issue - https://github.com/DeFiCh/wallet/issues/3885
#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
