### PR TITLE
fix(jellyfish-network): add missing devnet case

### DIFF
--- a/apps/legacy-api/src/pipes/NetworkValidationPipe.ts
+++ b/apps/legacy-api/src/pipes/NetworkValidationPipe.ts
@@ -5,7 +5,7 @@ import {
   PipeTransform
 } from '@nestjs/common'
 
-export type SupportedNetwork = 'mainnet' | 'testnet' | 'regtest'
+export type SupportedNetwork = 'mainnet' | 'testnet' | 'devnet' | 'regtest'
 
 @Injectable()
 export class NetworkValidationPipe implements PipeTransform {
@@ -13,6 +13,7 @@ export class NetworkValidationPipe implements PipeTransform {
     undefined, // defaults to 'mainnet'
     'mainnet',
     'testnet',
+    'devnet',
     'regtest'
   ])
 

--- a/packages/jellyfish-network/__tests__/Network.test.ts
+++ b/packages/jellyfish-network/__tests__/Network.test.ts
@@ -17,6 +17,11 @@ describe('getNetwork', () => {
     expect(getNetwork('testnet').bech32.hrp).toStrictEqual('tf')
   })
 
+  it('should get devnet', () => {
+    expect(getNetwork('devnet').name).toStrictEqual('devnet')
+    expect(getNetwork('devnet').bech32.hrp).toStrictEqual('tf')
+  })
+
   it('should get regtest', () => {
     expect(getNetwork('regtest').name).toStrictEqual('regtest')
     expect(getNetwork('regtest').bech32.hrp).toStrictEqual('bcrt')

--- a/packages/jellyfish-network/src/Network.ts
+++ b/packages/jellyfish-network/src/Network.ts
@@ -44,6 +44,8 @@ export function getNetwork (network: NetworkName): Network {
       return MainNet
     case 'testnet':
       return TestNet
+    case 'devnet':
+      return DevNet
     case 'regtest':
       return RegTest
     default:

--- a/packages/ocean-api-client/src/OceanApiClient.ts
+++ b/packages/ocean-api-client/src/OceanApiClient.ts
@@ -24,7 +24,7 @@ export interface OceanApiClientOptions {
   /**
    * Network that ocean client is configured to
    */
-  network?: 'mainnet' | 'testnet' | 'regtest' | string
+  network?: 'mainnet' | 'testnet' | 'devnet' | 'regtest' | string
 }
 
 /**


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes missing devnet case

#### Additional comments?:

Added support for `devnet` in `legacy-api` and `ocean-api-client` packages