### PR TITLE
chore(packages/jellyfish-api-core): fix descendants test flakiness with a deterministic setup

### DIFF
--- a/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolDescendants.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/getMempoolDescendants.test.ts
@@ -44,17 +44,32 @@ describe('Transactions without descendants', () => {
 describe('Transactions with descendants', () => {
   const container = new MasterNodeRegTestContainer()
   const testing = Testing.create(container)
+  let txIdWithDescendants: string
 
   beforeAll(async () => {
     await testing.container.start()
     await testing.container.waitForWalletCoinbaseMaturity()
+    txIdWithDescendants = await getTxIdWithDescendants()
   })
 
+  /**
+   * Reliably create Transaction with descendants by using the same UTXO for another transaction.
+   */
   async function getTxIdWithDescendants (): Promise<string> {
-    const txId = await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.003)
-    for (let i = 0; i < 10; i++) {
-      await testing.rpc.wallet.sendToAddress('mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU', 0.003)
-    }
+    const address = await testing.address(1)
+    const txId = await testing.rpc.wallet.sendToAddress(address, 20100)
+    const utxos = [{
+      txid: txId,
+      vout: 0
+    }]
+    await testing.rpc.token.createToken({
+      collateralAddress: address,
+      isDAT: false,
+      mintable: false,
+      name: 'DESC',
+      symbol: 'DESC',
+      tradeable: false
+    }, utxos)
     return txId
   }
 
@@ -63,11 +78,11 @@ describe('Transactions with descendants', () => {
   })
 
   it('should return JSON object if verbose is true', async () => {
-    const txIdWithDescendants = await getTxIdWithDescendants()
     const mempoolDescendants = await testing.rpc.blockchain.getMempoolDescendants(txIdWithDescendants, true)
 
     const keys = Object.keys(mempoolDescendants)
-    expect(keys.length).toBeGreaterThan(0)
+    expect(keys.length).toStrictEqual(1)
+
     for (const key of keys) {
       expect(mempoolDescendants[key]).toStrictEqual({
         fees: expect.any(Object),
@@ -84,28 +99,28 @@ describe('Transactions with descendants', () => {
         ancestorsize: expect.any(BigNumber),
         ancestorfees: expect.any(BigNumber),
         wtxid: expect.any(String),
-        depends: expect.any(Array),
-        spentby: expect.any(Array),
+        depends: [
+          txIdWithDescendants
+        ],
+        spentby: [],
         'bip125-replaceable': expect.any(Boolean)
       })
     }
   })
 
   it('should return array of transaction ids if verbose is false', async () => {
-    const txIdWithDescendants = await getTxIdWithDescendants()
     const mempoolDescendants = await testing.rpc.blockchain.getMempoolDescendants(txIdWithDescendants, false)
-    expect(mempoolDescendants.length).toBeGreaterThan(0)
-    for (const descendantId of mempoolDescendants) {
-      expect(descendantId).toStrictEqual(expect.stringMatching(/^[0-9a-f]{64}$/))
-    }
+
+    expect(mempoolDescendants).toStrictEqual([
+      expect.stringMatching(/^[0-9a-f]{64}$/)
+    ])
   })
 
   it('should return array of transaction ids if verbose is undefined', async () => {
-    const txIdWithDescendants = await getTxIdWithDescendants()
     const mempoolDescendants = await testing.rpc.blockchain.getMempoolDescendants(txIdWithDescendants)
-    expect(mempoolDescendants.length).toBeGreaterThan(0)
-    for (const descendantId of mempoolDescendants) {
-      expect(descendantId).toStrictEqual(expect.stringMatching(/^[0-9a-f]{64}$/))
-    }
+
+    expect(mempoolDescendants).toStrictEqual([
+      expect.stringMatching(/^[0-9a-f]{64}$/)
+    ])
   })
 })


### PR DESCRIPTION
#### What this PR does / why we need it:

Use a deterministic setup for `getMempoolDescendants` to prevent test flakiness.

Fixes part of #1771