### PR TITLE
chore(packages/jellyfish-wallet-encrypted): use simple `hardTime > easyTime` condition to reduce test flakiness

### DIFF
--- a/packages/jellyfish-wallet-encrypted/__tests__/scrypt.test.ts
+++ b/packages/jellyfish-wallet-encrypted/__tests__/scrypt.test.ts
@@ -32,5 +32,5 @@ it('configurable params (easy-hard)', async () => {
 
   // significantly slower
   // technically it is 8x harder, but they can be processed in parallel
-  expect(hardTime).toBeGreaterThan(easyTime * 2)
+  expect(hardTime).toBeGreaterThan(easyTime)
 })


### PR DESCRIPTION
#### What this PR does / why we need it:

I would forgo this test completely (if this is still causing flakiness) since we can't control (or should not) the CI environment. Tests concurrency within the pipeline (Jest concurrent and Docker spinup) skew "hardTime" and "easyTime" making the test number very unreliable.

We could isolate the tests but frankly too much trouble to prove an otherwise proven theory.

#### Which issue(s) does this PR fixes?:

Fixes part of #1771
