### PR TITLE
chore(apps/playground-api): fix flakiness in WalletController.test.ts by using `waitForExpect`

### DIFF
--- a/apps/playground-api/__tests__/controllers/WalletController.test.ts
+++ b/apps/playground-api/__tests__/controllers/WalletController.test.ts
@@ -1,5 +1,6 @@
 import { PlaygroundApiTesting } from '../../testing/PlaygroundApiTesting'
 import BigNumber from 'bignumber.js'
+import waitForExpect from 'wait-for-expect'
 
 const apiTesting = PlaygroundApiTesting.create()
 
@@ -26,13 +27,16 @@ describe('sendUtxo', () => {
     const txid = await apiTesting.client.wallet.sendUtxo('19.34153143', address)
     expect(txid.length).toStrictEqual(64)
 
-    const unspent = await apiTesting.rpc.wallet.listUnspent(1, 999999, {
-      addresses: [address]
-    })
+    // Added waitForExpect as `wallet.listUnspent` is known to be "flaky" as it run different on a separate wallet subsystem from blockchain core connectBlock
+    await waitForExpect(async () => {
+      const unspent = await apiTesting.rpc.wallet.listUnspent(1, 999999, {
+        addresses: [address]
+      })
 
-    expect(unspent.length).toStrictEqual(1)
-    expect(unspent[0].address).toStrictEqual(address)
-    expect(unspent[0].amount).toStrictEqual(new BigNumber('19.34153143'))
+      expect(unspent.length).toStrictEqual(1)
+      expect(unspent[0].address).toStrictEqual(address)
+      expect(unspent[0].amount).toStrictEqual(new BigNumber('19.34153143'))
+    })
   })
 
   it('should send token 0 to address and wait for automated block confirmation', async () => {


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `waitForExpect` for `wallet.listUnspent` within `WalletController.test.ts` as it's known to be "flaky" from testing; wallet operations run differently on a separate wallet subsystem from blockchain core `connectBlock`, a block might get connected first before your wallet entries get indexed.

#### Which issue(s) does this PR fixes?:

Fixes part of #1771 
