### PR TITLE
fix(whale-api-client): fixed listProposalVotes pagination api

### DIFF
--- a/apps/whale-api/src/module.api/governance.service.ts
+++ b/apps/whale-api/src/module.api/governance.service.ts
@@ -99,7 +99,10 @@ export class GovernanceService {
       }))
 
       return ApiPagedResponse.of(votes, size, () => {
-        return (votes.length - 1).toString()
+        if (next === undefined) {
+          return (votes.length - 1).toString()
+        }
+        return (next + votes.length).toString()
       })
     } catch (err) {
       if (

--- a/packages/whale-api-client/__tests__/api/governance.test.ts
+++ b/packages/whale-api-client/__tests__/api/governance.test.ts
@@ -326,10 +326,12 @@ describe('governance - listProposalVotes', () => {
     const result1 = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, masternode: MasternodeType.ALL, cycle: -1 })
     expect(result1.length).toStrictEqual(2)
     expect(result1.hasNext).toStrictEqual(true)
+    expect(result1.nextToken).toStrictEqual('1')
 
     const result2 = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, next: result1.nextToken, masternode: MasternodeType.ALL, cycle: -1 })
     expect(result2.length).toStrictEqual(2)
     expect(result2.hasNext).toStrictEqual(true)
+    expect(result2.nextToken).toStrictEqual('3')
 
     const result3 = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, next: result2.nextToken, masternode: MasternodeType.ALL, cycle: -1 })
     expect(result3.length).toStrictEqual(0)

--- a/packages/whale-api-client/__tests__/api/governance.test.ts
+++ b/packages/whale-api-client/__tests__/api/governance.test.ts
@@ -326,11 +326,11 @@ describe('governance - listProposalVotes', () => {
     const result1 = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, masternode: MasternodeType.ALL, cycle: -1 })
     expect(result1.length).toStrictEqual(2)
     expect(result1.hasNext).toStrictEqual(true)
-    
+
     const result2 = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, next: result1.nextToken, masternode: MasternodeType.ALL, cycle: -1 })
     expect(result2.length).toStrictEqual(2)
     expect(result2.hasNext).toStrictEqual(true)
-    
+
     const result3 = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, next: result2.nextToken, masternode: MasternodeType.ALL, cycle: -1 })
     expect(result3.length).toStrictEqual(0)
     expect(result3.hasNext).toStrictEqual(false)

--- a/packages/whale-api-client/__tests__/api/governance.test.ts
+++ b/packages/whale-api-client/__tests__/api/governance.test.ts
@@ -322,6 +322,19 @@ describe('governance - listProposalVotes', () => {
     expect(result.length).toStrictEqual(3)
   })
 
+  it('should listProposalVotes with pagination', async () => {
+    const result = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, masternode: MasternodeType.ALL, cycle: -1 })
+    expect(result.length).toStrictEqual(2)
+    expect(result.hasNext).toStrictEqual(true)
+    const result1 = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, next: result.nextToken, masternode: MasternodeType.ALL, cycle: -1 })
+    expect(result1.length).toStrictEqual(2)
+    expect(result1.hasNext).toStrictEqual(true)
+    const result2 = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, next: result1.nextToken, masternode: MasternodeType.ALL, cycle: -1 })
+    expect(result2.length).toStrictEqual(0)
+    expect(result2.hasNext).toStrictEqual(false)
+    expect(result2.nextToken).toStrictEqual(undefined)
+  })
+
   it('should listProposalVotes with all masternodes and cycle', async () => {
     const result = await client.governance.listGovProposalVotes({ id: cfpProposalId, masternode: MasternodeType.ALL, cycle: -1 })
     expect(result.length).toStrictEqual(4)

--- a/packages/whale-api-client/__tests__/api/governance.test.ts
+++ b/packages/whale-api-client/__tests__/api/governance.test.ts
@@ -323,16 +323,18 @@ describe('governance - listProposalVotes', () => {
   })
 
   it('should listProposalVotes with pagination', async () => {
-    const result = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, masternode: MasternodeType.ALL, cycle: -1 })
-    expect(result.length).toStrictEqual(2)
-    expect(result.hasNext).toStrictEqual(true)
-    const result1 = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, next: result.nextToken, masternode: MasternodeType.ALL, cycle: -1 })
+    const result1 = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, masternode: MasternodeType.ALL, cycle: -1 })
     expect(result1.length).toStrictEqual(2)
     expect(result1.hasNext).toStrictEqual(true)
+    
     const result2 = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, next: result1.nextToken, masternode: MasternodeType.ALL, cycle: -1 })
-    expect(result2.length).toStrictEqual(0)
-    expect(result2.hasNext).toStrictEqual(false)
-    expect(result2.nextToken).toStrictEqual(undefined)
+    expect(result2.length).toStrictEqual(2)
+    expect(result2.hasNext).toStrictEqual(true)
+    
+    const result3 = await client.governance.listGovProposalVotes({ id: cfpProposalId, size: 2, next: result2.nextToken, masternode: MasternodeType.ALL, cycle: -1 })
+    expect(result3.length).toStrictEqual(0)
+    expect(result3.hasNext).toStrictEqual(false)
+    expect(result3.nextToken).toStrictEqual(undefined)
   })
 
   it('should listProposalVotes with all masternodes and cycle', async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
In this pr we have fixed pagination issue in listProposalVotes listing
Previously to calculate next cursor we were using 

```
return ApiPagedResponse.of(votes, size, () => {
  return (votes.length - 1).toString()
})
```

Considering above logic if we have 20 voting and we fetch 10 voting list per api request then for 1st api request we will get next as 9 and in 2nd api request also we will get next as 9. this ends up with having unlimited pagination as it will display 11-20th voting list for all upcoming api response.
To fix this unlimited pagination we have updated the logic to consider previous next value to give expected result

```
return ApiPagedResponse.of(votes, size, () => {
  if (next === undefined) {
    return (votes.length - 1).toString()
  }
  return (next + votes.length).toString()
})
```

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
