### PR TITLE
feat(whale-api): whitelist getaddressinfo

### DIFF
--- a/apps/whale-api/src/module.api/rpc.controller.ts
+++ b/apps/whale-api/src/module.api/rpc.controller.ts
@@ -42,7 +42,8 @@ export class MethodWhitelist implements PipeTransform {
     'getrawtransaction',
     'getgovproposal',
     'listgovproposals',
-    'listgovproposalvotes'
+    'listgovproposalvotes',
+    'getaddressinfo'
   ]
 
   transform (value: string, metadata: ArgumentMetadata): string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Whitelisting `getaddressinfo` to be able to verify if address is owned by the wallet in bridge
- [ ] Checking if this can be used to verify if address is owned

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
