### PR TITLE
fix(apps/playground-api): fix PlaygroundProbeIndicator not registered

### DIFF
--- a/apps/playground-api/__tests__/controllers/ActuatorController.test.ts
+++ b/apps/playground-api/__tests__/controllers/ActuatorController.test.ts
@@ -23,11 +23,17 @@ describe('no peers', () => {
         details: {
           blockchain: {
             status: 'up'
+          },
+          playground: {
+            status: 'up'
           }
         },
         error: {},
         info: {
           blockchain: {
+            status: 'up'
+          },
+          playground: {
             status: 'up'
           }
         },
@@ -52,6 +58,9 @@ describe('no peers', () => {
             initialBlockDownload: expect.any(Boolean),
             peers: 0,
             status: 'down'
+          },
+          playground: {
+            status: 'up'
           }
         },
         error: {
@@ -63,7 +72,11 @@ describe('no peers', () => {
             status: 'down'
           }
         },
-        info: {},
+        info: {
+          playground: {
+            status: 'up'
+          }
+        },
         status: 'error'
       },
       error: {
@@ -101,11 +114,17 @@ describe('with peers', () => {
         details: {
           blockchain: {
             status: 'up'
+          },
+          playground: {
+            status: 'up'
           }
         },
         error: {},
         info: {
           blockchain: {
+            status: 'up'
+          },
+          playground: {
             status: 'up'
           }
         },
@@ -130,8 +149,10 @@ describe('with peers', () => {
             initialBlockDownload: false,
             peers: 1,
             status: 'up'
+          },
+          playground: {
+            status: 'up'
           }
-
         },
         error: {},
         info: {
@@ -140,6 +161,9 @@ describe('with peers', () => {
             headers: expect.any(Number),
             initialBlockDownload: false,
             peers: 1,
+            status: 'up'
+          },
+          playground: {
             status: 'up'
           }
         },

--- a/apps/playground-api/src/bots/Bot.ts
+++ b/apps/playground-api/src/bots/Bot.ts
@@ -1,11 +1,14 @@
 import { ApiClient } from '@defichain/jellyfish-api-core'
+import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
 import { Injectable } from '@nestjs/common'
-import { GenesisKeys } from '@defichain/testcontainers'
 import { Interval } from '@nestjs/schedule'
 
+/**
+ * @template Each
+ */
 @Injectable()
 export abstract class PlaygroundBot<Each> {
-  static MN_KEY = GenesisKeys[0]
+  static MN_KEY = RegTestFoundationKeys[0]
 
   /**
    * @return {string} address that should be used for everything

--- a/apps/playground-api/src/modules/PlaygroundModule.ts
+++ b/apps/playground-api/src/modules/PlaygroundModule.ts
@@ -16,6 +16,7 @@ import { SetupLoanCollateral } from '../setups/setup.loan.collateral'
 import { SetupGov } from '../setups/setup.gov'
 import { VaultBot } from '../bots/VaultBot'
 import { ScheduleModule } from '@nestjs/schedule'
+import { ActuatorProbes } from '@defichain-apps/libs/actuator'
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ export class PlaygroundModule implements OnApplicationBootstrap {
 
   constructor (
     private readonly client: ApiClient,
+    private readonly probes: ActuatorProbes,
     private readonly indicator: PlaygroundProbeIndicator,
     utxo: SetupUtxo,
     token: SetupToken,
@@ -69,6 +71,7 @@ export class PlaygroundModule implements OnApplicationBootstrap {
       dex,
       gov
     ]
+    this.probes.add(indicator)
   }
 
   async onApplicationBootstrap (): Promise<void> {

--- a/apps/playground-api/src/setups/setup.ts
+++ b/apps/playground-api/src/setups/setup.ts
@@ -3,6 +3,9 @@ import { Injectable, Logger } from '@nestjs/common'
 import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
 import { PlaygroundBlock } from '../PlaygroundBlock'
 
+/**
+ * @template Each
+ */
 @Injectable()
 export abstract class PlaygroundSetup<Each> {
   static MN_KEY = RegTestFoundationKeys[0]


### PR DESCRIPTION
#### What this PR does / why we need it:

As per title, this PR add the missing `PlaygroundProbeIndicator` to `ActuatorProbes`.

Additionally fixed a few deprecated usage.