### PR TITLE
feat(packages/testcontainers): add `PlaygroundApiContainer`

### DIFF
--- a/packages/testcontainers/__tests__/containers/PlaygroundApiContainer.test.ts
+++ b/packages/testcontainers/__tests__/containers/PlaygroundApiContainer.test.ts
@@ -1,0 +1,48 @@
+import { NativeChainContainer, StartedNativeChainContainer } from '@defichain/testcontainers'
+import { Network } from 'testcontainers'
+import {
+  StartedWhaleApiContainer,
+  WhaleApiContainer
+} from '@defichain/testcontainers/dist/containers/AppContainer/WhaleApiContainer'
+import {
+  PlaygroundApiContainer,
+  StartedPlaygroundApiContainer
+} from '@defichain/testcontainers/dist/containers/AppContainer/PlaygroundApiContainer'
+import { PlaygroundApiClient } from '@defichain/playground-api-client'
+
+let defid: StartedNativeChainContainer
+let whale: StartedWhaleApiContainer
+let playground: StartedPlaygroundApiContainer
+
+beforeAll(async () => {
+  const network = await new Network().start()
+
+  defid = await new NativeChainContainer()
+    .withNetwork(network)
+    .withPreconfiguredRegtestMasternode()
+    .start()
+
+  whale = await new WhaleApiContainer()
+    .withNetwork(network)
+    .withNativeChain(defid, network)
+    .start()
+
+  playground = await new PlaygroundApiContainer()
+    .withNetwork(network)
+    .withNativeChain(defid, network)
+    .start()
+})
+
+afterAll(async () => {
+  await whale.stop()
+  await defid.stop()
+  await playground.stop()
+})
+
+it('should waitForIndexedBlockHeight(100)', async () => {
+  await playground.waitForReady()
+
+  const api = new PlaygroundApiClient(playground.getPlaygroundApiClientOptions())
+  console.log(await api.playground.info())
+  // TODO(fuxingloh): check poolpair
+})

--- a/packages/testcontainers/__tests__/containers/WhaleApiContainer.test.ts
+++ b/packages/testcontainers/__tests__/containers/WhaleApiContainer.test.ts
@@ -1,10 +1,12 @@
-import { NativeChainContainer, StartedNativeChainContainer } from '@defichain/testcontainers'
 import { Network } from 'testcontainers'
+import { WhaleApiClient } from '@defichain/whale-api-client'
+
 import {
+  NativeChainContainer,
+  StartedNativeChainContainer,
   StartedWhaleApiContainer,
   WhaleApiContainer
-} from '@defichain/testcontainers/dist/containers/AppContainer/WhaleApiContainer'
-import { WhaleApiClient } from '@defichain/whale-api-client'
+} from '../../src'
 
 let defid: StartedNativeChainContainer
 let whale: StartedWhaleApiContainer

--- a/packages/testcontainers/src/containers/AppContainer/PlaygroundApiContainer.ts
+++ b/packages/testcontainers/src/containers/AppContainer/PlaygroundApiContainer.ts
@@ -65,7 +65,6 @@ export class StartedPlaygroundApiContainer extends AbstractStartedContainer {
         method: 'GET'
       })
       const { data } = await response.json()
-      console.log(data.details)
       return data.details.playground.status === 'up'
     }, timeout, 200, 'waitForIndexedBlockHeight')
   }

--- a/packages/testcontainers/src/containers/AppContainer/PlaygroundApiContainer.ts
+++ b/packages/testcontainers/src/containers/AppContainer/PlaygroundApiContainer.ts
@@ -1,0 +1,68 @@
+import { GenericContainer, StartedNetwork } from 'testcontainers'
+import { AbstractStartedContainer } from 'testcontainers/dist/modules/abstract-started-container'
+import { StartedNativeChainContainer, waitForCondition } from '@defichain/testcontainers'
+import packageJson from '../../../package.json'
+import fetch from 'cross-fetch'
+
+const PLAYGROUND_API_PORT = 3000
+
+/**
+ * For local environment, `:latest` tag will be used as there isn't pipeline to automatically rebuild image locally.
+ */
+const PLAYGROUND_VERSION = packageJson.version === '0.0.0' ? 'latest' : packageJson.version
+
+export class PlaygroundApiContainer extends GenericContainer {
+  constructor (image: string = `ghcr.io/jellyfishsdk/playground-api:${PLAYGROUND_VERSION}`) {
+    super(image)
+    this.withExposedPorts(PLAYGROUND_API_PORT).withStartupTimeout(120_000)
+  }
+
+  public withNativeChain (
+    container: StartedNativeChainContainer,
+    network: StartedNetwork
+  ): this {
+    const ipAddress = container.getIpAddress(network.getName())
+    this.withEnvironment({
+      PLAYGROUND_DEFID_URL: `http://${container.rpcUser}:${container.rpcPassword}@${ipAddress}:19554/`
+    })
+    return this
+  }
+
+  public async start (): Promise<StartedPlaygroundApiContainer> {
+    return new StartedPlaygroundApiContainer(await super.start())
+  }
+}
+
+export class StartedPlaygroundApiContainer extends AbstractStartedContainer {
+  public getContainerPort (): number {
+    return PLAYGROUND_API_PORT
+  }
+
+  public getPort (): number {
+    return this.getMappedPort(this.getContainerPort())
+  }
+
+  getEndpoint (): string {
+    return `http://localhost:${this.getPort()}`
+  }
+
+  getPlaygroundApiClientOptions (): { url: string, version: 'v0' } {
+    return {
+      url: this.getEndpoint(),
+      version: 'v0'
+    }
+  }
+
+  async waitForReady (timeout: number = 590000): Promise<void> {
+    const url = `${this.getEndpoint()}/_actuator/probes/readiness`
+
+    return await waitForCondition(async () => {
+      const response = await fetch(url, {
+        method: 'GET'
+      })
+      const { details } = await response.json()
+      console.log(details)
+      return details.playground.status === 'up'
+    }, timeout, 200, 'waitForIndexedBlockHeight')
+  }
+}

--- a/packages/testcontainers/src/containers/AppContainer/PlaygroundApiContainer.ts
+++ b/packages/testcontainers/src/containers/AppContainer/PlaygroundApiContainer.ts
@@ -1,15 +1,19 @@
 import { GenericContainer, StartedNetwork } from 'testcontainers'
 import { AbstractStartedContainer } from 'testcontainers/dist/modules/abstract-started-container'
-import { StartedNativeChainContainer, waitForCondition } from '@defichain/testcontainers'
-import packageJson from '../../../package.json'
+import { waitForCondition } from '../../utils'
+import { StartedNativeChainContainer } from '../NativeChainContainer'
 import fetch from 'cross-fetch'
 
-const PLAYGROUND_API_PORT = 3000
+// eslint-disable-next-line
+// @ts-ignore because `package.json` will always be available in the root of pnpm package
+import packageJson from '../../../package.json'
 
 /**
  * For local environment, `:latest` tag will be used as there isn't pipeline to automatically rebuild image locally.
  */
 const PLAYGROUND_VERSION = packageJson.version === '0.0.0' ? 'latest' : packageJson.version
+
+const PLAYGROUND_API_PORT = 3000
 
 export class PlaygroundApiContainer extends GenericContainer {
   constructor (image: string = `ghcr.io/jellyfishsdk/playground-api:${PLAYGROUND_VERSION}`) {
@@ -60,9 +64,9 @@ export class StartedPlaygroundApiContainer extends AbstractStartedContainer {
       const response = await fetch(url, {
         method: 'GET'
       })
-      const { details } = await response.json()
-      console.log(details)
-      return details.playground.status === 'up'
+      const { data } = await response.json()
+      console.log(data.details)
+      return data.details.playground.status === 'up'
     }, timeout, 200, 'waitForIndexedBlockHeight')
   }
 }

--- a/packages/testcontainers/src/index.ts
+++ b/packages/testcontainers/src/index.ts
@@ -22,6 +22,7 @@ export * from './containers/RegTestContainer/LoanContainer'
 
 export * from './containers/AppContainer/WhaleSanityContainer'
 export * from './containers/AppContainer/WhaleApiContainer'
+export * from './containers/AppContainer/PlaygroundApiContainer'
 
 export * from './containers/NativeChainContainer'
 export * from './containers/NativeChainRpc'


### PR DESCRIPTION
#### What this PR does / why we need it:

All the benefits for `playground-api` without the hassle of setting them up. Use it directly in Jest tests.

```ts
let defid: StartedNativeChainContainer
let whale: StartedWhaleApiContainer
let playground: StartedPlaygroundApiContainer

beforeAll(async () => {
  const network = await new Network().start()

  defid = await new NativeChainContainer()
    .withNetwork(network)
    .withPreconfiguredRegtestMasternode()
    .start()

  whale = await new WhaleApiContainer()
    .withNetwork(network)
    .withNativeChain(defid, network)
    .start()

  playground = await new PlaygroundApiContainer()
    .withNetwork(network)
    .withNativeChain(defid, network)
    .start()
})

afterAll(async () => {
  await whale.stop()
  await defid.stop()
  await playground.stop()
})

it('should playground.waitForReady() and do something with the setups', async () => {
  await playground.waitForReady()

  const whaleApi = new WhaleApiClient(whale.getWhaleApiClientOptions())
  console.log(await whaleApi.poolpairs.list(1))
})

```
