### PR TITLE
chore(renovate.json): auto bump testcontainers defi/defichain docker tag

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,5 +37,14 @@
       "matchPackagePatterns": ["jest"],
       "groupName": "jest"
     }
+  ],
+  "regexManagers": [
+    {
+      "datasourceTemplate": "docker",
+      "fileMatch": ["packages/testcontainers/src/.+Container\\.ts$"],
+      "matchStrings": [
+        "    return '(?<depName>.*?):(?<currentValue>.*?)' // renovate.json regexManagers"
+      ]
+    }
   ]
 }

--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -36,7 +36,7 @@ export abstract class DeFiDContainer extends DockerContainer {
     if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
       return process.env.DEFICHAIN_DOCKER_IMAGE
     }
-    return 'defi/defichain:HEAD-5e41f6f20'
+    return 'defi/defichain:HEAD-5e41f6f20' // renovate.json regexManagers
   }
 
   public static readonly DefaultStartOptions = {

--- a/packages/testcontainers/src/containers/NativeChainContainer.ts
+++ b/packages/testcontainers/src/containers/NativeChainContainer.ts
@@ -30,7 +30,7 @@ export class NativeChainContainer extends GenericContainer {
     if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
       return process.env.DEFICHAIN_DOCKER_IMAGE
     }
-    return 'defi/defichain:3.2.2'
+    return 'defi/defichain:3.2.2' // renovate.json regexManagers
   }
 
   public static readonly PREFIX = 'defichain-testcontainers-'
@@ -157,6 +157,7 @@ export class NativeChainContainer extends GenericContainer {
   }
 
   private readonly addedCmds: string[] = []
+
   public addCmd (newCmd: string): this {
     this.addedCmds.push(newCmd)
     return this


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Add `regexManagers` in renovate.json to auto bump defi/defichain docker images.

Fixes #1850