### PR TITLE
chore(testcontainers): increase testTimeout 300 secs to cater for more complex playground tests

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -78,7 +78,6 @@
     "@types/validator": "13.7.11",
     "source-map-support": "0.5.21",
     "supertest": "6.3.3",
-    "testcontainers": "8.16.0",
     "ts-loader": "9.4.2",
     "ts-node": "10.9.1",
     "tsconfig-paths": "4.1.0"

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   verbose: true,
   clearMocks: true,
-  testTimeout: 180000,
+  testTimeout: 300000,
   testPathIgnorePatterns: [
     '__sanity__'
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,6 @@
         "@types/validator": "13.7.11",
         "source-map-support": "0.5.21",
         "supertest": "6.3.3",
-        "testcontainers": "8.16.0",
         "ts-loader": "9.4.2",
         "ts-node": "10.9.1",
         "tsconfig-paths": "4.1.0"
@@ -23402,26 +23401,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/testcontainers": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-8.16.0.tgz",
-      "integrity": "sha512-4wVmnzj4mAVXSQ8kU4uyNiXPs5W8UHdwCRbUuyeOSSODcgmDGQ8Te/YOYuF12HnxyzABEm1nR2I0ZCsQw/GZ/Q==",
-      "dev": true,
-      "dependencies": {
-        "@balena/dockerignore": "^1.0.2",
-        "@types/archiver": "^5.3.1",
-        "@types/dockerode": "^3.3.8",
-        "archiver": "^5.3.1",
-        "byline": "^5.0.0",
-        "debug": "^4.3.4",
-        "docker-compose": "^0.23.17",
-        "dockerode": "^3.3.1",
-        "get-port": "^5.1.1",
-        "properties-reader": "^2.2.0",
-        "ssh-remote-port-forward": "^1.0.4",
-        "tar-fs": "^2.1.1"
-      }
-    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -25839,6 +25818,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@defichain/jellyfish-transaction": "^0.0.0",
+        "@defichain/jellyfish-wallet": "^0.0.0",
         "bip32": "^2.0.6",
         "bip39": "^3.0.4",
         "create-hmac": "^1.1.7"
@@ -25913,7 +25894,7 @@
         "cross-fetch": "^3.1.5",
         "dockerode": "^3.3.4",
         "tar-fs": "^2.1.1",
-        "testcontainers": "^9.0.1",
+        "testcontainers": "^9.1.1",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -25926,9 +25907,9 @@
       }
     },
     "packages/testcontainers/node_modules/testcontainers": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-9.0.1.tgz",
-      "integrity": "sha512-ZT9H6Gjqm8OWc8Dmvk0oZlk/T6+pTKTKgQnbbivmWy2/WHt45AKMs1czpkmVACdSS3Z7zaLiTxyrcx8I6S9sPA==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-9.1.1.tgz",
+      "integrity": "sha512-4vTjKQWZxpMA+pNFlpupZ3XCdcbisYwbZIVUYFaNxl9bk8Vi/ELDzZJ3Kr14WdG7Q7333BGaZjKgKtx/ouEuMg==",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
         "@types/archiver": "^5.3.1",
@@ -25939,6 +25920,7 @@
         "docker-compose": "^0.23.17",
         "dockerode": "^3.3.4",
         "get-port": "^5.1.1",
+        "node-fetch": "^2.6.7",
         "properties-reader": "^2.2.0",
         "ssh-remote-port-forward": "^1.0.4",
         "tar-fs": "^2.1.1"
@@ -27574,7 +27556,6 @@
         "source-map-support": "0.5.21",
         "subleveldown": "^6.0.1",
         "supertest": "6.3.3",
-        "testcontainers": "8.16.0",
         "ts-loader": "9.4.2",
         "ts-node": "10.9.1",
         "tsconfig-paths": "4.1.0"
@@ -27791,6 +27772,8 @@
     "@defichain/jellyfish-wallet-mnemonic": {
       "version": "file:packages/jellyfish-wallet-mnemonic",
       "requires": {
+        "@defichain/jellyfish-transaction": "^0.0.0",
+        "@defichain/jellyfish-wallet": "^0.0.0",
         "@types/create-hmac": "1.1.0",
         "bip32": "^2.0.6",
         "bip39": "^3.0.4",
@@ -27838,14 +27821,14 @@
         "cross-fetch": "^3.1.5",
         "dockerode": "^3.3.4",
         "tar-fs": "^2.1.1",
-        "testcontainers": "^9.0.1",
+        "testcontainers": "^9.1.1",
         "uuid": "^9.0.0"
       },
       "dependencies": {
         "testcontainers": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-9.0.1.tgz",
-          "integrity": "sha512-ZT9H6Gjqm8OWc8Dmvk0oZlk/T6+pTKTKgQnbbivmWy2/WHt45AKMs1czpkmVACdSS3Z7zaLiTxyrcx8I6S9sPA==",
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-9.1.1.tgz",
+          "integrity": "sha512-4vTjKQWZxpMA+pNFlpupZ3XCdcbisYwbZIVUYFaNxl9bk8Vi/ELDzZJ3Kr14WdG7Q7333BGaZjKgKtx/ouEuMg==",
           "requires": {
             "@balena/dockerignore": "^1.0.2",
             "@types/archiver": "^5.3.1",
@@ -27856,6 +27839,7 @@
             "docker-compose": "^0.23.17",
             "dockerode": "^3.3.4",
             "get-port": "^5.1.1",
+            "node-fetch": "^2.6.7",
             "properties-reader": "^2.2.0",
             "ssh-remote-port-forward": "^1.0.4",
             "tar-fs": "^2.1.1"
@@ -35696,7 +35680,6 @@
             "source-map-support": "0.5.21",
             "subleveldown": "^6.0.1",
             "supertest": "6.3.3",
-            "testcontainers": "8.16.0",
             "ts-loader": "9.4.2",
             "ts-node": "10.9.1",
             "tsconfig-paths": "4.1.0"
@@ -35913,6 +35896,8 @@
         "@defichain/jellyfish-wallet-mnemonic": {
           "version": "file:packages/jellyfish-wallet-mnemonic",
           "requires": {
+            "@defichain/jellyfish-transaction": "^0.0.0",
+            "@defichain/jellyfish-wallet": "^0.0.0",
             "@types/create-hmac": "1.1.0",
             "bip32": "^2.0.6",
             "bip39": "^3.0.4",
@@ -35960,14 +35945,14 @@
             "cross-fetch": "^3.1.5",
             "dockerode": "^3.3.4",
             "tar-fs": "^2.1.1",
-            "testcontainers": "^9.0.1",
+            "testcontainers": "^9.1.1",
             "uuid": "^9.0.0"
           },
           "dependencies": {
             "testcontainers": {
-              "version": "9.0.1",
-              "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-9.0.1.tgz",
-              "integrity": "sha512-ZT9H6Gjqm8OWc8Dmvk0oZlk/T6+pTKTKgQnbbivmWy2/WHt45AKMs1czpkmVACdSS3Z7zaLiTxyrcx8I6S9sPA==",
+              "version": "9.1.1",
+              "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-9.1.1.tgz",
+              "integrity": "sha512-4vTjKQWZxpMA+pNFlpupZ3XCdcbisYwbZIVUYFaNxl9bk8Vi/ELDzZJ3Kr14WdG7Q7333BGaZjKgKtx/ouEuMg==",
               "requires": {
                 "@balena/dockerignore": "^1.0.2",
                 "@types/archiver": "^5.3.1",
@@ -35978,6 +35963,7 @@
                 "docker-compose": "^0.23.17",
                 "dockerode": "^3.3.4",
                 "get-port": "^5.1.1",
+                "node-fetch": "^2.6.7",
                 "properties-reader": "^2.2.0",
                 "ssh-remote-port-forward": "^1.0.4",
                 "tar-fs": "^2.1.1"
@@ -50817,26 +50803,6 @@
             "minimatch": "^3.0.4"
           }
         },
-        "testcontainers": {
-          "version": "8.16.0",
-          "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-8.16.0.tgz",
-          "integrity": "sha512-4wVmnzj4mAVXSQ8kU4uyNiXPs5W8UHdwCRbUuyeOSSODcgmDGQ8Te/YOYuF12HnxyzABEm1nR2I0ZCsQw/GZ/Q==",
-          "dev": true,
-          "requires": {
-            "@balena/dockerignore": "^1.0.2",
-            "@types/archiver": "^5.3.1",
-            "@types/dockerode": "^3.3.8",
-            "archiver": "^5.3.1",
-            "byline": "^5.0.0",
-            "debug": "^4.3.4",
-            "docker-compose": "^0.23.17",
-            "dockerode": "^3.3.1",
-            "get-port": "^5.1.1",
-            "properties-reader": "^2.2.0",
-            "ssh-remote-port-forward": "^1.0.4",
-            "tar-fs": "^2.1.1"
-          }
-        },
         "text-extensions": {
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -60837,26 +60803,6 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
-      }
-    },
-    "testcontainers": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-8.16.0.tgz",
-      "integrity": "sha512-4wVmnzj4mAVXSQ8kU4uyNiXPs5W8UHdwCRbUuyeOSSODcgmDGQ8Te/YOYuF12HnxyzABEm1nR2I0ZCsQw/GZ/Q==",
-      "dev": true,
-      "requires": {
-        "@balena/dockerignore": "^1.0.2",
-        "@types/archiver": "^5.3.1",
-        "@types/dockerode": "^3.3.8",
-        "archiver": "^5.3.1",
-        "byline": "^5.0.0",
-        "debug": "^4.3.4",
-        "docker-compose": "^0.23.17",
-        "dockerode": "^3.3.1",
-        "get-port": "^5.1.1",
-        "properties-reader": "^2.2.0",
-        "ssh-remote-port-forward": "^1.0.4",
-        "tar-fs": "^2.1.1"
       }
     },
     "text-extensions": {

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -19,7 +19,7 @@
     "dockerode": "^3.3.4",
     "tar-fs": "^2.1.1",
     "uuid": "^9.0.0",
-    "testcontainers": "^9.0.1"
+    "testcontainers": "^9.1.1"
   },
   "peerDependencies": {
     "@types/tar-fs": "^2.0.1",

--- a/packages/testcontainers/src/containers/AppContainer/PlaygroundApiContainer.ts
+++ b/packages/testcontainers/src/containers/AppContainer/PlaygroundApiContainer.ts
@@ -66,6 +66,6 @@ export class StartedPlaygroundApiContainer extends AbstractStartedContainer {
       })
       const { data } = await response.json()
       return data.details.playground.status === 'up'
-    }, timeout, 200, 'waitForIndexedBlockHeight')
+    }, timeout, 200, 'waitForReady')
   }
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

As per title.

Also bumped testcontainers to 9.1.1 and removed testcontainers in `apps/package.json`.
