### PR TITLE
chore(jellyfish-api-core): update voteGov tests and docs after v3.2.4

### DIFF
--- a/packages/jellyfish-api-core/__tests__/category/governance/voteGov.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/governance/voteGov.test.ts
@@ -56,7 +56,7 @@ describe('Governance', () => {
 
     const promise = client.governance.voteGov({ proposalId, masternodeId, decision: VoteDecision.YES })
     await expect(promise).rejects.toThrow(RpcApiError)
-    await expect(promise).rejects.toThrow(`RpcApiError: 'The masternode ${masternodeId} does not exist', code: -8, method: votegov`)
+    await expect(promise).rejects.toThrow(`The masternode does not exist or the address doesn't own a masternode: ${masternodeId}', code: -8, method: votegov`)
   })
 
   it('should not vote on a proposal with an inactive masternode', async () => {

--- a/packages/jellyfish-api-core/src/category/governance.ts
+++ b/packages/jellyfish-api-core/src/category/governance.ts
@@ -124,7 +124,7 @@ export class Governance {
    *
    * @param {VoteData} data Vote data
    * @param {string} data.proposalId Proposal id
-   * @param {number} data.masternodeId Masternode id
+   * @param {number} data.masternodeId Masternode id/owner address/operator address
    * @param {VoteDecision} data.decision Vote decision. See VoteDecision.
    * @param {UTXO[]} [utxos = []] Specific utxos to spend
    * @param {string} [utxos.txid] The transaction id

--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -36,7 +36,7 @@ export abstract class DeFiDContainer extends DockerContainer {
     if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
       return process.env.DEFICHAIN_DOCKER_IMAGE
     }
-    return 'defi/defichain:3.2.3' // renovate.json regexManagers
+    return 'defi/defichain:3.2.4' // renovate.json regexManagers
   }
 
   public static readonly DefaultStartOptions = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

voteGov can now accept an operator address in addition to the masternode ID. The error was updated to account for this change, which breaks the tests. This PR updates the tests to expect the new error.
