### PR TITLE
feat(jellyfish-api-core): add addMultiSigAddress RPC

### DIFF
--- a/docs/node/CATEGORIES/05-wallet.md
+++ b/docs/node/CATEGORIES/05-wallet.md
@@ -407,3 +407,19 @@ interface wallet {
   signMessage (address: string, message: string): Promise<string>
 }
 ```
+
+## addMultiSigAddress
+
+Add an nrequired-to-sign multisignature address to the wallet. Requires a new wallet backup.
+
+```ts title="client.wallet.signMessage()"
+interface wallet {
+  addMultiSigAddress (nrequired: number, keys: string): Promise<MultiSigAddressResult>
+}
+
+interface MultiSigAddressResult {
+  address: string
+  redeemScript: string
+  descriptor: string
+}
+```

--- a/docs/node/CATEGORIES/05-wallet.md
+++ b/docs/node/CATEGORIES/05-wallet.md
@@ -412,9 +412,9 @@ interface wallet {
 
 Add an nrequired-to-sign multisignature address to the wallet. Requires a new wallet backup.
 
-```ts title="client.wallet.signMessage()"
+```ts title="client.wallet.addMultiSigAddress()"
 interface wallet {
-  addMultiSigAddress (nrequired: number, keys: string): Promise<MultiSigAddressResult>
+  addMultiSigAddress (nRequired: number, keys: string, label?: string, addressType?: string): Promise<MultiSigAddressResult>
 }
 
 interface MultiSigAddressResult {

--- a/packages/jellyfish-api-core/__tests__/category/wallet/addMultiSigAddress.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/addMultiSigAddress.test.ts
@@ -1,0 +1,48 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { ContainerAdapterClient } from '../../container_adapter_client'
+import { RpcApiError } from '@defichain/jellyfish-api-core'
+
+describe('Wallet with masternode', () => {
+  const container = new MasterNodeRegTestContainer()
+  const client = new ContainerAdapterClient(container)
+
+  beforeAll(async () => {
+    await container.start()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should throw error when number of keys provided =/= nrequired', async () => {
+    const n = 3
+    const pubKeyA = await client.wallet.getNewAddress()
+    const pubKeyB = await client.wallet.getNewAddress()
+    const keys = [pubKeyA, pubKeyB]
+
+    const promise = await client.wallet.addMultiSigAddress(n, keys)
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toMatchObject({
+      payload: {
+        code: -8,
+        message: 'not enough keys supplied (got 2 keys, but need at least 3 to redeem)',
+        method: 'addmultisigaddress'
+      }
+    })
+  })
+
+  it('should throw error when public key provided is invalid', async () => {
+    const n = 3
+    const pubKey = ['invalid key']
+
+    const promise = await client.wallet.addMultiSigAddress(n, pubKey)
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toMatchObject({
+      payload: {
+        code: -5,
+        message: 'Invalid address: invalid key',
+        method: 'addmultisigaddress'
+      }
+    })
+  })
+})

--- a/packages/jellyfish-api-core/src/category/wallet.ts
+++ b/packages/jellyfish-api-core/src/category/wallet.ts
@@ -336,6 +336,19 @@ export class Wallet {
   async signMessage (address: string, message: string): Promise<string> {
     return await this.client.call('signmessage', [address, message], 'number')
   }
+
+  /**
+   * Add an nrequired-to-sign multisignature address to the wallet. Requires a new wallet backup.
+   *
+   * @param {number} nRequired The number of required signatures based on number of keys/addresses.
+   * @param {string[]} keys The DeFi addresses or hex-encoded public keys.
+   * @param {string} label optional, a label to assign the addresses to.
+   * @param {string} addressType optional, the address type to use. E.g: “legacy”, “p2sh-segwit”, and “bech32”.
+   * @return {Promise<MultiSigAddressResult>}
+   */
+  async addMultiSigAddress (nRequired: number, keys: string[], label?: string, addressType?: string): Promise<MultiSigAddressResult> {
+    return await this.client.call('addmultisigaddress', [nRequired, keys, label, addressType], 'number')
+  }
 }
 
 export interface UTXO {
@@ -520,4 +533,10 @@ export interface WalletWatchOnlyBalances {
   trusted: BigNumber
   untrusted_pending: BigNumber
   immature: BigNumber
+}
+
+export interface MultiSigAddressResult {
+  address: string
+  redeemScript: string
+  descriptor: string
 }


### PR DESCRIPTION
**What this PR does / why we need it:**
/kind feature

**Which issue(s) does this PR fixes?:**
Adds `addMultiSigAddress` from [Issue#48 ](https://github.com/JellyfishSDK/jellyfish/issues/48)

**Additional comments?:**
This functionality is only intended for use with non-watchonly addresses.
