### PR TITLE
feat(jellyfish-api-core): add wallet.listtransactions RPC

### DIFF
--- a/docs/node/CATEGORIES/05-wallet.md
+++ b/docs/node/CATEGORIES/05-wallet.md
@@ -408,12 +408,19 @@ interface wallet {
 }
 ```
 
- ## listTransactions
+## listTransactions
 
- List transactions based on the given criteria.
+List transactions based on the given criteria.
 
- ```ts title="client.wallet.listTransactions()"
- interface wallet {
-   listTransactions  (label: string = '*', count: number = 10, skip: number = 0, includeWatchOnly: boolean = true, excludeCustomTx: boolean = true): Promise<InWalletTransactionWithCategory[]>
- }
- ```
+```ts title="client.wallet.listTransactions()"
+interface wallet {
+  listTransactions  ({
+    label?: string = '*',
+    count?: number = 10,
+    skip?: number = 0,
+    includeWatchOnly?: boolean = true
+    excludeCustomTx?: boolean = false
+  }): Promise<InWalletTransactionWithCategory[]>
+}
+```
+

--- a/docs/node/CATEGORIES/05-wallet.md
+++ b/docs/node/CATEGORIES/05-wallet.md
@@ -407,3 +407,13 @@ interface wallet {
   signMessage (address: string, message: string): Promise<string>
 }
 ```
+
+ ## listTransactions
+
+ List transactions based on the given criteria.
+
+ ```ts title="client.wallet.listTransactions()"
+ interface wallet {
+   listTransactions  (label: string = '*', count: number = 10, skip: number = 0, includeWatchOnly: boolean = true, excludeCustomTx: boolean = true): Promise<InWalletTransactionWithCategory[]>
+ }
+ ```

--- a/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
@@ -64,7 +64,7 @@ describe('listTransactions', () => {
       expect(inWalletTransaction.label).toStrictEqual('owner')
     })
 
-    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(numTx)
+    expect(inWalletTransactions.length).toBe(numTx)
 
     for (const inWalletTransaction of inWalletTransactions) {
       expect(inWalletTransaction).toMatchObject({

--- a/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
@@ -171,7 +171,6 @@ describe('listTransactions', () => {
     }
   })
 
-  // TODO: it should listTransactions with excludeCustomTx = false
   it('should listTransactions with excludeCustomTx = true', async () => {
     const inWalletTransactions = await client.wallet.listTransactions('*', 10, 0, undefined, true)
 

--- a/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
@@ -22,7 +22,7 @@ describe('listTransactions', () => {
     await client.wallet.sendToAddress(address, 0.0001)
     await container.generate(1, address)
 
-    const inWalletTransactions = await client.wallet.listTransactions()
+    const inWalletTransactions = await client.wallet.listTransactions({})
 
     expect(inWalletTransactions.length).toBeGreaterThanOrEqual(1)
 
@@ -49,7 +49,7 @@ describe('listTransactions', () => {
     await client.wallet.sendToAddress(address, 0.0001)
     await container.generate(1, address)
 
-    const inWalletTransactions = await client.wallet.listTransactions('owner')
+    const inWalletTransactions = await client.wallet.listTransactions({ label: 'owner' })
 
     inWalletTransactions.forEach((inWalletTransaction) => {
       expect(inWalletTransaction.label).toStrictEqual('owner')
@@ -80,7 +80,7 @@ describe('listTransactions', () => {
     await client.wallet.sendToAddress(address, 0.0001)
     await container.generate(1, address)
 
-    const inWalletTransactions = await client.wallet.listTransactions('owner')
+    const inWalletTransactions = await client.wallet.listTransactions({ label: 'owner' })
 
     inWalletTransactions.forEach((inWalletTransaction) => {
       expect(inWalletTransaction.label).toStrictEqual('owner')
@@ -111,7 +111,7 @@ describe('listTransactions', () => {
     await client.wallet.sendToAddress(address, 0.0001)
     await container.generate(1, address)
 
-    const inWalletTransactions = await client.wallet.listTransactions('*', 5)
+    const inWalletTransactions = await client.wallet.listTransactions({ count: 5 })
 
     expect(inWalletTransactions.length).toStrictEqual(5)
 
@@ -135,16 +135,16 @@ describe('listTransactions', () => {
   })
 
   it('should not listTransactions with count = -1', async () => {
-    await expect(client.wallet.listTransactions('*', -1)).rejects.toThrow('RpcApiError: \'Negative count\', code: -8, method: listtransactions')
+    await expect(client.wallet.listTransactions({ count: -1 })).rejects.toThrow('RpcApiError: \'Negative count\', code: -8, method: listtransactions')
   })
 
   it('should listTransactions with count = 0', async () => {
-    const inWalletTransactions = await client.wallet.listTransactions('*', 0)
+    const inWalletTransactions = await client.wallet.listTransactions({ count: 0 })
     expect(inWalletTransactions.length).toStrictEqual(0)
   })
 
   it('should listTransactions with includeWatchOnly false', async () => {
-    const inWalletTransactions = await client.wallet.listTransactions('*', 10, 0, false, undefined)
+    const inWalletTransactions = await client.wallet.listTransactions({ includeWatchOnly: false })
 
     inWalletTransactions.forEach((inWalletTransaction) => {
       expect(inWalletTransaction.address).toStrictEqual(address)
@@ -172,7 +172,7 @@ describe('listTransactions', () => {
   })
 
   it('should listTransactions with excludeCustomTx = true', async () => {
-    const inWalletTransactions = await client.wallet.listTransactions('*', 10, 0, undefined, true)
+    const inWalletTransactions = await client.wallet.listTransactions({ excludeCustomTx: true })
 
     inWalletTransactions.forEach((inWalletTransaction) => {
       expect(inWalletTransaction.address).toStrictEqual(address)

--- a/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
@@ -1,4 +1,3 @@
-import { BIP125, InWalletTransactionCategory } from '@defichain/jellyfish-api-core/dist/category/wallet'
 import { BigNumber } from '@defichain/jellyfish-json'
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { ContainerAdapterClient } from '../../container_adapter_client'
@@ -19,34 +18,80 @@ describe('listTransactions', () => {
   })
 
   it('should listTransactions', async () => {
-    await client.wallet.sendToAddress(address, 0.0001)
+    const numTx = 10
+
+    for (let i = 0; i < numTx; i += 1) {
+      await client.wallet.sendToAddress(address, 0.0001)
+    }
     await container.generate(1, address)
 
     const inWalletTransactions = await client.wallet.listTransactions({})
 
-    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(1)
+    expect(inWalletTransactions.length).toBe(numTx)
 
     for (const inWalletTransaction of inWalletTransactions) {
-      expect(typeof inWalletTransaction.address).toStrictEqual('string')
-      expect(typeof inWalletTransaction.txid).toStrictEqual('string')
-      expect(inWalletTransaction.amount).toBeInstanceOf(BigNumber)
-
-      expect(typeof inWalletTransaction.confirmations).toStrictEqual('number')
-      expect(typeof inWalletTransaction.blockhash).toStrictEqual('string')
-      expect(typeof inWalletTransaction.blocktime).toStrictEqual('number')
-      expect(typeof inWalletTransaction.blockindex).toStrictEqual('number')
-      expect(typeof inWalletTransaction.time).toStrictEqual('number')
-      expect(typeof inWalletTransaction.timereceived).toStrictEqual('number')
-      expect(Object.values(BIP125).includes(inWalletTransaction['bip125-replaceable'])).toStrictEqual(true)
-
-      expect(Object.values(InWalletTransactionCategory).includes(inWalletTransaction.category)).toStrictEqual(true)
-      expect(typeof inWalletTransaction.label).toStrictEqual('string')
-      expect(typeof inWalletTransaction.vout).toStrictEqual('number')
+      expect(inWalletTransaction).toMatchObject({
+        address: expect.any(String),
+        txid: expect.any(String),
+        amount: expect.any(BigNumber),
+        confirmations: expect.any(Number),
+        blockhash: expect.any(String),
+        blocktime: expect.any(Number),
+        blockindex: expect.any(Number),
+        time: expect.any(Number),
+        timereceived: expect.any(Number),
+        // "bip125-replaceable" is "BIP125" enum but we test with "string" here
+        'bip125-replaceable': expect.any(String),
+        // "category" is "InWalletTransactionCategory" enum but we test with "string" here
+        category: expect.any(String),
+        label: expect.any(String),
+        vout: expect.any(Number)
+      })
     }
   })
 
   it('should listTransactions with label set', async () => {
-    await client.wallet.sendToAddress(address, 0.0001)
+    const numTx = 10
+
+    for (let i = 0; i < numTx; i += 1) {
+      await client.wallet.sendToAddress(address, 0.0001)
+    }
+    await container.generate(1, address)
+
+    const inWalletTransactions = await client.wallet.listTransactions({ label: 'owner' })
+
+    inWalletTransactions.forEach((inWalletTransaction) => {
+      expect(inWalletTransaction.label).toStrictEqual('owner')
+    })
+
+    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(numTx)
+
+    for (const inWalletTransaction of inWalletTransactions) {
+      expect(inWalletTransaction).toMatchObject({
+        address: expect.any(String),
+        txid: expect.any(String),
+        amount: expect.any(BigNumber),
+        confirmations: expect.any(Number),
+        blockhash: expect.any(String),
+        blocktime: expect.any(Number),
+        blockindex: expect.any(Number),
+        time: expect.any(Number),
+        timereceived: expect.any(Number),
+        // "bip125-replaceable" is "BIP125" enum but we test with "string" here
+        'bip125-replaceable': expect.any(String),
+        // "category" is "InWalletTransactionCategory" enum but we test with "string" here
+        category: expect.any(String),
+        label: expect.any(String),
+        vout: expect.any(Number)
+      })
+    }
+  })
+
+  it('should listTransactions with label set', async () => {
+    const numTx = 10
+    for (let i = 0; i < numTx; i += 1) {
+      await client.wallet.sendToAddress(address, 0.0001)
+    }
     await container.generate(1, address)
 
     const inWalletTransactions = await client.wallet.listTransactions({ label: 'owner' })
@@ -58,52 +103,23 @@ describe('listTransactions', () => {
     expect(inWalletTransactions.length).toBeGreaterThanOrEqual(1)
 
     for (const inWalletTransaction of inWalletTransactions) {
-      expect(typeof inWalletTransaction.address).toStrictEqual('string')
-      expect(typeof inWalletTransaction.txid).toStrictEqual('string')
-      expect(inWalletTransaction.amount).toBeInstanceOf(BigNumber)
-
-      expect(typeof inWalletTransaction.confirmations).toStrictEqual('number')
-      expect(typeof inWalletTransaction.blockhash).toStrictEqual('string')
-      expect(typeof inWalletTransaction.blocktime).toStrictEqual('number')
-      expect(typeof inWalletTransaction.blockindex).toStrictEqual('number')
-      expect(typeof inWalletTransaction.time).toStrictEqual('number')
-      expect(typeof inWalletTransaction.timereceived).toStrictEqual('number')
-      expect(Object.values(BIP125).includes(inWalletTransaction['bip125-replaceable'])).toStrictEqual(true)
-
-      expect(Object.values(InWalletTransactionCategory).includes(inWalletTransaction.category)).toStrictEqual(true)
-      expect(typeof inWalletTransaction.label).toStrictEqual('string')
-      expect(typeof inWalletTransaction.vout).toStrictEqual('number')
-    }
-  })
-
-  it('should listTransactions with label set', async () => {
-    await client.wallet.sendToAddress(address, 0.0001)
-    await container.generate(1, address)
-
-    const inWalletTransactions = await client.wallet.listTransactions({ label: 'owner' })
-
-    inWalletTransactions.forEach((inWalletTransaction) => {
-      expect(inWalletTransaction.label).toStrictEqual('owner')
-    })
-
-    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(1)
-
-    for (const inWalletTransaction of inWalletTransactions) {
-      expect(typeof inWalletTransaction.address).toStrictEqual('string')
-      expect(typeof inWalletTransaction.txid).toStrictEqual('string')
-      expect(inWalletTransaction.amount).toBeInstanceOf(BigNumber)
-
-      expect(typeof inWalletTransaction.confirmations).toStrictEqual('number')
-      expect(typeof inWalletTransaction.blockhash).toStrictEqual('string')
-      expect(typeof inWalletTransaction.blocktime).toStrictEqual('number')
-      expect(typeof inWalletTransaction.blockindex).toStrictEqual('number')
-      expect(typeof inWalletTransaction.time).toStrictEqual('number')
-      expect(typeof inWalletTransaction.timereceived).toStrictEqual('number')
-      expect(Object.values(BIP125).includes(inWalletTransaction['bip125-replaceable'])).toStrictEqual(true)
-
-      expect(Object.values(InWalletTransactionCategory).includes(inWalletTransaction.category)).toStrictEqual(true)
-      expect(typeof inWalletTransaction.label).toStrictEqual('string')
-      expect(typeof inWalletTransaction.vout).toStrictEqual('number')
+      expect(inWalletTransaction).toMatchObject({
+        address: expect.any(String),
+        txid: expect.any(String),
+        amount: expect.any(BigNumber),
+        confirmations: expect.any(Number),
+        blockhash: expect.any(String),
+        blocktime: expect.any(Number),
+        blockindex: expect.any(Number),
+        time: expect.any(Number),
+        timereceived: expect.any(Number),
+        // "bip125-replaceable" is "BIP125" enum but we test with "string" here
+        'bip125-replaceable': expect.any(String),
+        // "category" is "InWalletTransactionCategory" enum but we test with "string" here
+        category: expect.any(String),
+        label: expect.any(String),
+        vout: expect.any(Number)
+      })
     }
   })
 
@@ -116,21 +132,23 @@ describe('listTransactions', () => {
     expect(inWalletTransactions.length).toStrictEqual(5)
 
     for (const inWalletTransaction of inWalletTransactions) {
-      expect(typeof inWalletTransaction.address).toStrictEqual('string')
-      expect(typeof inWalletTransaction.txid).toStrictEqual('string')
-      expect(inWalletTransaction.amount).toBeInstanceOf(BigNumber)
-
-      expect(typeof inWalletTransaction.confirmations).toStrictEqual('number')
-      expect(typeof inWalletTransaction.blockhash).toStrictEqual('string')
-      expect(typeof inWalletTransaction.blocktime).toStrictEqual('number')
-      expect(typeof inWalletTransaction.blockindex).toStrictEqual('number')
-      expect(typeof inWalletTransaction.time).toStrictEqual('number')
-      expect(typeof inWalletTransaction.timereceived).toStrictEqual('number')
-      expect(Object.values(BIP125).includes(inWalletTransaction['bip125-replaceable'])).toStrictEqual(true)
-
-      expect(Object.values(InWalletTransactionCategory).includes(inWalletTransaction.category)).toStrictEqual(true)
-      expect(typeof inWalletTransaction.label).toStrictEqual('string')
-      expect(typeof inWalletTransaction.vout).toStrictEqual('number')
+      expect(inWalletTransaction).toMatchObject({
+        address: expect.any(String),
+        txid: expect.any(String),
+        amount: expect.any(BigNumber),
+        confirmations: expect.any(Number),
+        blockhash: expect.any(String),
+        blocktime: expect.any(Number),
+        blockindex: expect.any(Number),
+        time: expect.any(Number),
+        timereceived: expect.any(Number),
+        // "bip125-replaceable" is "BIP125" enum but we test with "string" here
+        'bip125-replaceable': expect.any(String),
+        // "category" is "InWalletTransactionCategory" enum but we test with "string" here
+        category: expect.any(String),
+        label: expect.any(String),
+        vout: expect.any(Number)
+      })
     }
   })
 
@@ -153,49 +171,60 @@ describe('listTransactions', () => {
     expect(inWalletTransactions.length).toBeGreaterThanOrEqual(1)
 
     for (const inWalletTransaction of inWalletTransactions) {
-      expect(typeof inWalletTransaction.address).toStrictEqual('string')
-      expect(typeof inWalletTransaction.txid).toStrictEqual('string')
-      expect(inWalletTransaction.amount).toBeInstanceOf(BigNumber)
-
-      expect(typeof inWalletTransaction.confirmations).toStrictEqual('number')
-      expect(typeof inWalletTransaction.blockhash).toStrictEqual('string')
-      expect(typeof inWalletTransaction.blocktime).toStrictEqual('number')
-      expect(typeof inWalletTransaction.blockindex).toStrictEqual('number')
-      expect(typeof inWalletTransaction.time).toStrictEqual('number')
-      expect(typeof inWalletTransaction.timereceived).toStrictEqual('number')
-      expect(Object.values(BIP125).includes(inWalletTransaction['bip125-replaceable'])).toStrictEqual(true)
-
-      expect(Object.values(InWalletTransactionCategory).includes(inWalletTransaction.category)).toStrictEqual(true)
-      expect(typeof inWalletTransaction.label).toStrictEqual('string')
-      expect(typeof inWalletTransaction.vout).toStrictEqual('number')
+      expect(inWalletTransaction).toMatchObject({
+        address: expect.any(String),
+        txid: expect.any(String),
+        amount: expect.any(BigNumber),
+        confirmations: expect.any(Number),
+        blockhash: expect.any(String),
+        blocktime: expect.any(Number),
+        blockindex: expect.any(Number),
+        time: expect.any(Number),
+        timereceived: expect.any(Number),
+        // "bip125-replaceable" is "BIP125" enum but we test with "string" here
+        'bip125-replaceable': expect.any(String),
+        // "category" is "InWalletTransactionCategory" enum but we test with "string" here
+        category: expect.any(String),
+        label: expect.any(String),
+        vout: expect.any(Number)
+      })
     }
   })
 
   it('should listTransactions with excludeCustomTx = true', async () => {
+    const numTx = 10
+
+    for (let i = 0; i < numTx; i += 1) {
+      await client.wallet.sendToAddress(address, 0.0001)
+    }
+    await container.generate(1, address)
+
     const inWalletTransactions = await client.wallet.listTransactions({ excludeCustomTx: true })
 
     inWalletTransactions.forEach((inWalletTransaction) => {
       expect(inWalletTransaction.address).toStrictEqual(address)
     })
 
-    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(1)
+    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(numTx)
 
     for (const inWalletTransaction of inWalletTransactions) {
-      expect(typeof inWalletTransaction.address).toStrictEqual('string')
-      expect(typeof inWalletTransaction.txid).toStrictEqual('string')
-      expect(inWalletTransaction.amount).toBeInstanceOf(BigNumber)
-
-      expect(typeof inWalletTransaction.confirmations).toStrictEqual('number')
-      expect(typeof inWalletTransaction.blockhash).toStrictEqual('string')
-      expect(typeof inWalletTransaction.blocktime).toStrictEqual('number')
-      expect(typeof inWalletTransaction.blockindex).toStrictEqual('number')
-      expect(typeof inWalletTransaction.time).toStrictEqual('number')
-      expect(typeof inWalletTransaction.timereceived).toStrictEqual('number')
-      expect(Object.values(BIP125).includes(inWalletTransaction['bip125-replaceable'])).toStrictEqual(true)
-
-      expect(Object.values(InWalletTransactionCategory).includes(inWalletTransaction.category)).toStrictEqual(true)
-      expect(typeof inWalletTransaction.label).toStrictEqual('string')
-      expect(typeof inWalletTransaction.vout).toStrictEqual('number')
+      expect(inWalletTransaction).toMatchObject({
+        address: expect.any(String),
+        txid: expect.any(String),
+        amount: expect.any(BigNumber),
+        confirmations: expect.any(Number),
+        blockhash: expect.any(String),
+        blocktime: expect.any(Number),
+        blockindex: expect.any(Number),
+        time: expect.any(Number),
+        timereceived: expect.any(Number),
+        // "bip125-replaceable" is "BIP125" enum but we test with "string" here
+        'bip125-replaceable': expect.any(String),
+        // "category" is "InWalletTransactionCategory" enum but we test with "string" here
+        category: expect.any(String),
+        label: expect.any(String),
+        vout: expect.any(Number)
+      })
     }
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
@@ -1,0 +1,202 @@
+import { BIP125, InWalletTransactionCategory } from '@defichain/jellyfish-api-core/dist/category/wallet'
+import { BigNumber } from '@defichain/jellyfish-json'
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { ContainerAdapterClient } from '../../container_adapter_client'
+
+describe('listTransactions', () => {
+  const container = new MasterNodeRegTestContainer()
+  const client = new ContainerAdapterClient(container)
+
+  const address = 'mwsZw8nF7pKxWH8eoKL9tPxTpaFkz7QeLU'
+
+  beforeAll(async () => {
+    await container.start()
+    await container.waitForWalletCoinbaseMaturity()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should listTransactions', async () => {
+    await client.wallet.sendToAddress(address, 0.0001)
+    await container.generate(1, address)
+
+    const inWalletTransactions = await client.wallet.listTransactions()
+
+    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(1)
+
+    for (const inWalletTransaction of inWalletTransactions) {
+      expect(typeof inWalletTransaction.address).toStrictEqual('string')
+      expect(typeof inWalletTransaction.txid).toStrictEqual('string')
+      expect(inWalletTransaction.amount).toBeInstanceOf(BigNumber)
+
+      expect(typeof inWalletTransaction.confirmations).toStrictEqual('number')
+      expect(typeof inWalletTransaction.blockhash).toStrictEqual('string')
+      expect(typeof inWalletTransaction.blocktime).toStrictEqual('number')
+      expect(typeof inWalletTransaction.blockindex).toStrictEqual('number')
+      expect(typeof inWalletTransaction.time).toStrictEqual('number')
+      expect(typeof inWalletTransaction.timereceived).toStrictEqual('number')
+      expect(Object.values(BIP125).includes(inWalletTransaction['bip125-replaceable'])).toStrictEqual(true)
+
+      expect(Object.values(InWalletTransactionCategory).includes(inWalletTransaction.category)).toStrictEqual(true)
+      expect(typeof inWalletTransaction.label).toStrictEqual('string')
+      expect(typeof inWalletTransaction.vout).toStrictEqual('number')
+    }
+  })
+
+  it('should listTransactions with label set', async () => {
+    await client.wallet.sendToAddress(address, 0.0001)
+    await container.generate(1, address)
+
+    const inWalletTransactions = await client.wallet.listTransactions('owner')
+
+    inWalletTransactions.forEach((inWalletTransaction) => {
+      expect(inWalletTransaction.label).toStrictEqual('owner')
+    })
+
+    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(1)
+
+    for (const inWalletTransaction of inWalletTransactions) {
+      expect(typeof inWalletTransaction.address).toStrictEqual('string')
+      expect(typeof inWalletTransaction.txid).toStrictEqual('string')
+      expect(inWalletTransaction.amount).toBeInstanceOf(BigNumber)
+
+      expect(typeof inWalletTransaction.confirmations).toStrictEqual('number')
+      expect(typeof inWalletTransaction.blockhash).toStrictEqual('string')
+      expect(typeof inWalletTransaction.blocktime).toStrictEqual('number')
+      expect(typeof inWalletTransaction.blockindex).toStrictEqual('number')
+      expect(typeof inWalletTransaction.time).toStrictEqual('number')
+      expect(typeof inWalletTransaction.timereceived).toStrictEqual('number')
+      expect(Object.values(BIP125).includes(inWalletTransaction['bip125-replaceable'])).toStrictEqual(true)
+
+      expect(Object.values(InWalletTransactionCategory).includes(inWalletTransaction.category)).toStrictEqual(true)
+      expect(typeof inWalletTransaction.label).toStrictEqual('string')
+      expect(typeof inWalletTransaction.vout).toStrictEqual('number')
+    }
+  })
+
+  it('should listTransactions with label set', async () => {
+    await client.wallet.sendToAddress(address, 0.0001)
+    await container.generate(1, address)
+
+    const inWalletTransactions = await client.wallet.listTransactions('owner')
+
+    inWalletTransactions.forEach((inWalletTransaction) => {
+      expect(inWalletTransaction.label).toStrictEqual('owner')
+    })
+
+    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(1)
+
+    for (const inWalletTransaction of inWalletTransactions) {
+      expect(typeof inWalletTransaction.address).toStrictEqual('string')
+      expect(typeof inWalletTransaction.txid).toStrictEqual('string')
+      expect(inWalletTransaction.amount).toBeInstanceOf(BigNumber)
+
+      expect(typeof inWalletTransaction.confirmations).toStrictEqual('number')
+      expect(typeof inWalletTransaction.blockhash).toStrictEqual('string')
+      expect(typeof inWalletTransaction.blocktime).toStrictEqual('number')
+      expect(typeof inWalletTransaction.blockindex).toStrictEqual('number')
+      expect(typeof inWalletTransaction.time).toStrictEqual('number')
+      expect(typeof inWalletTransaction.timereceived).toStrictEqual('number')
+      expect(Object.values(BIP125).includes(inWalletTransaction['bip125-replaceable'])).toStrictEqual(true)
+
+      expect(Object.values(InWalletTransactionCategory).includes(inWalletTransaction.category)).toStrictEqual(true)
+      expect(typeof inWalletTransaction.label).toStrictEqual('string')
+      expect(typeof inWalletTransaction.vout).toStrictEqual('number')
+    }
+  })
+
+  it('should listTransactions with count = 5', async () => {
+    await client.wallet.sendToAddress(address, 0.0001)
+    await container.generate(1, address)
+
+    const inWalletTransactions = await client.wallet.listTransactions('*', 5)
+
+    expect(inWalletTransactions.length).toStrictEqual(5)
+
+    for (const inWalletTransaction of inWalletTransactions) {
+      expect(typeof inWalletTransaction.address).toStrictEqual('string')
+      expect(typeof inWalletTransaction.txid).toStrictEqual('string')
+      expect(inWalletTransaction.amount).toBeInstanceOf(BigNumber)
+
+      expect(typeof inWalletTransaction.confirmations).toStrictEqual('number')
+      expect(typeof inWalletTransaction.blockhash).toStrictEqual('string')
+      expect(typeof inWalletTransaction.blocktime).toStrictEqual('number')
+      expect(typeof inWalletTransaction.blockindex).toStrictEqual('number')
+      expect(typeof inWalletTransaction.time).toStrictEqual('number')
+      expect(typeof inWalletTransaction.timereceived).toStrictEqual('number')
+      expect(Object.values(BIP125).includes(inWalletTransaction['bip125-replaceable'])).toStrictEqual(true)
+
+      expect(Object.values(InWalletTransactionCategory).includes(inWalletTransaction.category)).toStrictEqual(true)
+      expect(typeof inWalletTransaction.label).toStrictEqual('string')
+      expect(typeof inWalletTransaction.vout).toStrictEqual('number')
+    }
+  })
+
+  it('should not listTransactions with count = -1', async () => {
+    await expect(client.wallet.listTransactions('*', -1)).rejects.toThrow('RpcApiError: \'Negative count\', code: -8, method: listtransactions')
+  })
+
+  it('should listTransactions with count = 0', async () => {
+    const inWalletTransactions = await client.wallet.listTransactions('*', 0)
+    expect(inWalletTransactions.length).toStrictEqual(0)
+  })
+
+  it('should listTransactions with includeWatchOnly false', async () => {
+    const inWalletTransactions = await client.wallet.listTransactions('*', 10, 0, false, undefined)
+
+    inWalletTransactions.forEach((inWalletTransaction) => {
+      expect(inWalletTransaction.address).toStrictEqual(address)
+    })
+
+    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(1)
+
+    for (const inWalletTransaction of inWalletTransactions) {
+      expect(typeof inWalletTransaction.address).toStrictEqual('string')
+      expect(typeof inWalletTransaction.txid).toStrictEqual('string')
+      expect(inWalletTransaction.amount).toBeInstanceOf(BigNumber)
+
+      expect(typeof inWalletTransaction.confirmations).toStrictEqual('number')
+      expect(typeof inWalletTransaction.blockhash).toStrictEqual('string')
+      expect(typeof inWalletTransaction.blocktime).toStrictEqual('number')
+      expect(typeof inWalletTransaction.blockindex).toStrictEqual('number')
+      expect(typeof inWalletTransaction.time).toStrictEqual('number')
+      expect(typeof inWalletTransaction.timereceived).toStrictEqual('number')
+      expect(Object.values(BIP125).includes(inWalletTransaction['bip125-replaceable'])).toStrictEqual(true)
+
+      expect(Object.values(InWalletTransactionCategory).includes(inWalletTransaction.category)).toStrictEqual(true)
+      expect(typeof inWalletTransaction.label).toStrictEqual('string')
+      expect(typeof inWalletTransaction.vout).toStrictEqual('number')
+    }
+  })
+
+  // TODO: it should listTransactions with excludeCustomTx = false
+  it('should listTransactions with excludeCustomTx = true', async () => {
+    const inWalletTransactions = await client.wallet.listTransactions('*', 10, 0, undefined, true)
+
+    inWalletTransactions.forEach((inWalletTransaction) => {
+      expect(inWalletTransaction.address).toStrictEqual(address)
+    })
+
+    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(1)
+
+    for (const inWalletTransaction of inWalletTransactions) {
+      expect(typeof inWalletTransaction.address).toStrictEqual('string')
+      expect(typeof inWalletTransaction.txid).toStrictEqual('string')
+      expect(inWalletTransaction.amount).toBeInstanceOf(BigNumber)
+
+      expect(typeof inWalletTransaction.confirmations).toStrictEqual('number')
+      expect(typeof inWalletTransaction.blockhash).toStrictEqual('string')
+      expect(typeof inWalletTransaction.blocktime).toStrictEqual('number')
+      expect(typeof inWalletTransaction.blockindex).toStrictEqual('number')
+      expect(typeof inWalletTransaction.time).toStrictEqual('number')
+      expect(typeof inWalletTransaction.timereceived).toStrictEqual('number')
+      expect(Object.values(BIP125).includes(inWalletTransaction['bip125-replaceable'])).toStrictEqual(true)
+
+      expect(Object.values(InWalletTransactionCategory).includes(inWalletTransaction.category)).toStrictEqual(true)
+      expect(typeof inWalletTransaction.label).toStrictEqual('string')
+      expect(typeof inWalletTransaction.vout).toStrictEqual('number')
+    }
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
@@ -18,16 +18,14 @@ describe('listTransactions', () => {
   })
 
   it('should listTransactions', async () => {
-    const numTx = 10
-
-    for (let i = 0; i < numTx; i += 1) {
+    for (let i = 0; i < 10; i += 1) {
       await client.wallet.sendToAddress(address, 0.0001)
     }
     await container.generate(1, address)
 
     const inWalletTransactions = await client.wallet.listTransactions({})
 
-    expect(inWalletTransactions.length).toBe(numTx)
+    expect(inWalletTransactions.length).toStrictEqual(10)
 
     for (const inWalletTransaction of inWalletTransactions) {
       expect(inWalletTransaction).toMatchObject({
@@ -51,9 +49,7 @@ describe('listTransactions', () => {
   })
 
   it('should listTransactions with label set', async () => {
-    const numTx = 10
-
-    for (let i = 0; i < numTx; i += 1) {
+    for (let i = 0; i < 10; i += 1) {
       await client.wallet.sendToAddress(address, 0.0001)
     }
     await container.generate(1, address)
@@ -64,7 +60,7 @@ describe('listTransactions', () => {
       expect(inWalletTransaction.label).toStrictEqual('owner')
     })
 
-    expect(inWalletTransactions.length).toBe(numTx)
+    expect(inWalletTransactions.length).toStrictEqual(10)
 
     for (const inWalletTransaction of inWalletTransactions) {
       expect(inWalletTransaction).toMatchObject({
@@ -88,8 +84,7 @@ describe('listTransactions', () => {
   })
 
   it('should listTransactions with label set', async () => {
-    const numTx = 10
-    for (let i = 0; i < numTx; i += 1) {
+    for (let i = 0; i < 10; i += 1) {
       await client.wallet.sendToAddress(address, 0.0001)
     }
     await container.generate(1, address)
@@ -100,7 +95,7 @@ describe('listTransactions', () => {
       expect(inWalletTransaction.label).toStrictEqual('owner')
     })
 
-    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(1)
+    expect(inWalletTransactions.length).toStrictEqual(10)
 
     for (const inWalletTransaction of inWalletTransactions) {
       expect(inWalletTransaction).toMatchObject({
@@ -162,13 +157,18 @@ describe('listTransactions', () => {
   })
 
   it('should listTransactions with includeWatchOnly false', async () => {
+    for (let i = 0; i < 10; i += 1) {
+      await client.wallet.sendToAddress(address, 0.0001)
+    }
+    await container.generate(1, address)
+
     const inWalletTransactions = await client.wallet.listTransactions({ includeWatchOnly: false })
 
     inWalletTransactions.forEach((inWalletTransaction) => {
       expect(inWalletTransaction.address).toStrictEqual(address)
     })
 
-    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(1)
+    expect(inWalletTransactions.length).toStrictEqual(10)
 
     for (const inWalletTransaction of inWalletTransactions) {
       expect(inWalletTransaction).toMatchObject({
@@ -192,9 +192,7 @@ describe('listTransactions', () => {
   })
 
   it('should listTransactions with excludeCustomTx = true', async () => {
-    const numTx = 10
-
-    for (let i = 0; i < numTx; i += 1) {
+    for (let i = 0; i < 10; i += 1) {
       await client.wallet.sendToAddress(address, 0.0001)
     }
     await container.generate(1, address)
@@ -205,7 +203,7 @@ describe('listTransactions', () => {
       expect(inWalletTransaction.address).toStrictEqual(address)
     })
 
-    expect(inWalletTransactions.length).toBeGreaterThanOrEqual(numTx)
+    expect(inWalletTransactions.length).toStrictEqual(10)
 
     for (const inWalletTransaction of inWalletTransactions) {
       expect(inWalletTransaction).toMatchObject({

--- a/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/listTransactions.test.ts
@@ -18,9 +18,9 @@ describe('listTransactions', () => {
   })
 
   it('should listTransactions', async () => {
-    for (let i = 0; i < 10; i += 1) {
-      await client.wallet.sendToAddress(address, 0.0001)
-    }
+    await Promise.all(Array.from({ length: 10 }).map(async (_, i) => {
+      return await client.wallet.sendToAddress(address, 0.0001)
+    }))
     await container.generate(1, address)
 
     const inWalletTransactions = await client.wallet.listTransactions({})
@@ -49,9 +49,9 @@ describe('listTransactions', () => {
   })
 
   it('should listTransactions with label set', async () => {
-    for (let i = 0; i < 10; i += 1) {
-      await client.wallet.sendToAddress(address, 0.0001)
-    }
+    await Promise.all(Array.from({ length: 10 }).map(async (_, i) => {
+      return await client.wallet.sendToAddress(address, 0.0001)
+    }))
     await container.generate(1, address)
 
     const inWalletTransactions = await client.wallet.listTransactions({ label: 'owner' })
@@ -84,9 +84,9 @@ describe('listTransactions', () => {
   })
 
   it('should listTransactions with label set', async () => {
-    for (let i = 0; i < 10; i += 1) {
-      await client.wallet.sendToAddress(address, 0.0001)
-    }
+    await Promise.all(Array.from({ length: 10 }).map(async (_, i) => {
+      return await client.wallet.sendToAddress(address, 0.0001)
+    }))
     await container.generate(1, address)
 
     const inWalletTransactions = await client.wallet.listTransactions({ label: 'owner' })
@@ -119,7 +119,9 @@ describe('listTransactions', () => {
   })
 
   it('should listTransactions with count = 5', async () => {
-    await client.wallet.sendToAddress(address, 0.0001)
+    await Promise.all(Array.from({ length: 5 }).map(async (_, i) => {
+      return await client.wallet.sendToAddress(address, 0.0001)
+    }))
     await container.generate(1, address)
 
     const inWalletTransactions = await client.wallet.listTransactions({ count: 5 })
@@ -157,9 +159,9 @@ describe('listTransactions', () => {
   })
 
   it('should listTransactions with includeWatchOnly false', async () => {
-    for (let i = 0; i < 10; i += 1) {
-      await client.wallet.sendToAddress(address, 0.0001)
-    }
+    await Promise.all(Array.from({ length: 10 }).map(async (_, i) => {
+      return await client.wallet.sendToAddress(address, 0.0001)
+    }))
     await container.generate(1, address)
 
     const inWalletTransactions = await client.wallet.listTransactions({ includeWatchOnly: false })
@@ -192,9 +194,9 @@ describe('listTransactions', () => {
   })
 
   it('should listTransactions with excludeCustomTx = true', async () => {
-    for (let i = 0; i < 10; i += 1) {
-      await client.wallet.sendToAddress(address, 0.0001)
-    }
+    await Promise.all(Array.from({ length: 10 }).map(async (_, i) => {
+      return await client.wallet.sendToAddress(address, 0.0001)
+    }))
     await container.generate(1, address)
 
     const inWalletTransactions = await client.wallet.listTransactions({ excludeCustomTx: true })

--- a/packages/jellyfish-api-core/src/category/wallet.ts
+++ b/packages/jellyfish-api-core/src/category/wallet.ts
@@ -336,7 +336,19 @@ export class Wallet {
    * @param {boolean} excludeCustomTx False to include all transactions, otherwise exclude custom transactions (default = false)
    * @return {Promise<Array<InWalletTransactionWithFlatDetails>>}
    */
-  async listTransactions (label: string = '*', count: number = 10, skip: number = 0, includeWatchOnly: boolean = true, excludeCustomTx: boolean = false): Promise<InWalletTransactionWithFlatDetails[]> {
+  async listTransactions ({
+    label = '*',
+    count = 10,
+    skip = 0,
+    includeWatchOnly = true,
+    excludeCustomTx = false
+  }: {
+    label?: string
+    count?: number
+    skip?: number
+    includeWatchOnly?: boolean
+    excludeCustomTx?: boolean
+  }): Promise<InWalletTransactionWithFlatDetails[]> {
     return await this.client.call('listtransactions', [label, count, skip, includeWatchOnly, excludeCustomTx], { amount: 'bignumber' })
   }
 

--- a/packages/jellyfish-api-core/src/category/wallet.ts
+++ b/packages/jellyfish-api-core/src/category/wallet.ts
@@ -326,6 +326,21 @@ export class Wallet {
   }
 
   /**
+   * If a label name is provided, this will return only incoming transactions paying to addresses with the specified label.
+   * Returns up to 'count' most recent transactions skipping the first 'from' transactions.
+   *
+   * @param {string} label If set, should be a valid label name to return only incoming transactions with the specified label, or '*' to disable filtering and return all transactions. (default = '*')
+   * @param {string} count The number of transactions to return (default = 10)
+   * @param {string} skip The number of transactions to skip (default = 0)
+   * @param {boolean} includeWatchOnly Whether to include watch-only addresses (default = true)
+   * @param {boolean} excludeCustomTx False to include all transactions, otherwise exclude custom transactions (default = false)
+   * @return {Promise<Array<InWalletTransactionWithFlatDetails>>}
+   */
+  async listTransactions (label: string = '*', count: number = 10, skip: number = 0, includeWatchOnly: boolean = true, excludeCustomTx: boolean = false): Promise<InWalletTransactionWithFlatDetails[]> {
+    return await this.client.call('listtransactions', [label, count, skip, includeWatchOnly, excludeCustomTx], { amount: 'bignumber' })
+  }
+
+  /**
    * Sign a message with the private key of an address
    * Requires wallet to be unlocked for usage. Use `walletpassphrase` to unlock wallet.
    *
@@ -492,6 +507,26 @@ export interface InWalletTransaction {
   bip125replaceable?: BIP125
   details: InWalletTransactionDetail[]
   hex: string
+}
+
+export interface InWalletTransactionWithFlatDetails {
+  address: string
+  category: InWalletTransactionCategory
+  amount: BigNumber
+  label?: string
+  vout: number
+  fee?: number
+  confirmations: number
+  trusted: boolean
+  blockhash: string
+  blockindex: number
+  blocktime: number
+  txid: string
+  time: number
+  timereceived: number
+  comment?: string
+  'bip125-replaceable': BIP125
+  abandoned?: boolean
 }
 
 export interface InWalletTransactionDetail {


### PR DESCRIPTION
#### What this PR does / why we need it:

/kind feature

#### Which issue(s) does this PR fixes?:
Implemented RPC call for https://github.com/JellyfishSDK/jellyfish/issues/48
1. wallet.listtransactions

#### Additional comments?:
- Unsure how to test the "skip" parameter for the `wallet.listtransactions` function