### PR TITLE
chore(apps/whale-api): increase getLoanInfo cache ttl

### DIFF
--- a/apps/whale-api/src/module.api/stats.controller.ts
+++ b/apps/whale-api/src/module.api/stats.controller.ts
@@ -128,7 +128,7 @@ export class StatsController {
   private async getLoanInfo (): Promise<GetLoanInfoResult> {
     return await this.cachedGet('Controller.stats.getLoanInfo', async () => {
       return await this.rpcClient.loan.getLoanInfo()
-    }, 777)
+    }, 1234)
   }
 
   private async getCachedBurnTotal (): Promise<BigNumber> {


### PR DESCRIPTION
#### What this PR does / why we need it:

Increase `getLoanInfo` cache TTL duration for better infrastructure reliability.