### PR TITLE
chore(apps/whale-api): update poolpairs to ignore token symbols with `BURN`

### DIFF
--- a/apps/whale-api/src/module.api/poolpair.controller.e2e.ts
+++ b/apps/whale-api/src/module.api/poolpair.controller.e2e.ts
@@ -9,7 +9,6 @@ import { DeFiDCache } from './cache/defid.cache'
 import { CachePrefix } from '@defichain-apps/libs/caches'
 import { Cache } from 'cache-manager'
 import { TokenInfo } from '@defichain/jellyfish-api-core/dist/category/token'
-import { PoolPairData, TokenIdentifier } from '@defichain/whale-api-client/dist/api/poolpairs'
 
 const container = new MasterNodeRegTestContainer()
 let app: NestFastifyApplication
@@ -283,13 +282,9 @@ describe('list', () => {
     const response = await controller.list({
       size: 30
     })
-    const burn = ['BURN', 'BURN2']
+    const burnTokens = ['BURN', 'BURN2']
 
-    function doBurnAndPoolPairsIntersect (poolpairs: PoolPairData[], burnTokens: string[]): boolean {
-      return poolpairs.some(poolpair => burnTokens.includes(poolpair.symbol))
-    }
-
-    expect(doBurnAndPoolPairsIntersect(response.data, burn)).toBe(false)
+    expect(response.data.some(poolpair => burnTokens.includes(poolpair.symbol))).toBe(false)
   })
 
   it('should list with pagination', async () => {
@@ -1000,11 +995,7 @@ describe('get list swappable tokens', () => {
     const result = await controller.listSwappableTokens('1') // A
     const unswappableTokens = ['BURN', 'BURN2']
 
-    function doUnswappableAndSwappableTokensIntersect (swappableTokens: TokenIdentifier[], unswappableTokens: string[]): boolean {
-      return swappableTokens.some(token => unswappableTokens.includes(token.symbol))
-    }
-
-    expect(doUnswappableAndSwappableTokensIntersect(result.swappableTokens, unswappableTokens)).toBe(false)
+    expect(result.swappableTokens.some(token => unswappableTokens.includes(token.symbol))).toBe(false)
   })
 
   it('should list no tokens for token that is not swappable with any', async () => {

--- a/apps/whale-api/src/module.api/poolpair.controller.e2e.ts
+++ b/apps/whale-api/src/module.api/poolpair.controller.e2e.ts
@@ -180,6 +180,18 @@ async function setup (): Promise<void> {
     shareAddress: await getNewAddress(container)
   })
 
+  // BURN2 should not be listed as Swappable
+  await createToken(container, 'BURN2')
+  await createPoolPair(container, 'BURN2', 'DFI', { status: false })
+  await mintTokens(container, 'BURN2', { mintAmount: 1 })
+  await addPoolLiquidity(container, {
+    tokenA: 'BURN2',
+    amountA: 1,
+    tokenB: 'DFI',
+    amountB: 1,
+    shareAddress: await getNewAddress(container)
+  })
+
   await container.call('setgov', [{ LP_SPLITS: { 16: 1.0 } }])
   await container.generate(1)
 
@@ -276,7 +288,7 @@ describe('list', () => {
     expect(first.data[1].symbol).toStrictEqual('B-DFI')
 
     const next = await controller.list({
-      size: 14,
+      size: 15,
       next: first.page?.next
     })
 

--- a/apps/whale-api/src/module.api/poolpair.controller.ts
+++ b/apps/whale-api/src/module.api/poolpair.controller.ts
@@ -64,7 +64,7 @@ export class PoolPairController {
       return item.id
     })
     response.data = response.data.filter(value => {
-      return !value.symbol.startsWith('BURN-')
+      return !value.symbol.includes('BURN')
     })
     return response
   }

--- a/apps/whale-api/src/module.api/poolpair.prices.service.ts
+++ b/apps/whale-api/src/module.api/poolpair.prices.service.ts
@@ -89,7 +89,7 @@ export class PoolPairPricesService {
   }
 
   private isUntradeableToken (token: TokenInfoWithId): boolean {
-    return token.isLPS || !token.isDAT || token.symbol === 'BURN' || !token.tradeable
+    return token.isLPS || !token.isDAT || token.symbol.includes('BURN') || !token.tradeable
   }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Updated `poolpair.controller.ts` 
to ignore symbols with `BURN` eg `BURN`, `BURN2` and not only `BURN`

and `poolpair.prices.services.ts` to include symbols with `BURN` as untradeableToken

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
This PR is to be put on hold as we are exploring on showing `BURN` without implying that they are tradable
