### PR TITLE
feat(jellyfish-json): add support for bigint stringify

### DIFF
--- a/packages/jellyfish-json/__tests__/index.test.ts
+++ b/packages/jellyfish-json/__tests__/index.test.ts
@@ -68,7 +68,7 @@ describe('stringify', () => {
     const string = JellyfishJSON.stringify({
       bigint: new BigInt('120000000000000001')
     })
-    expect(string).toStrictEqual('{"bigint":120000000000000001n}')
+    expect(string).toStrictEqual('{"bigint":120000000000000001}')
   })
 })
 

--- a/packages/jellyfish-json/__tests__/index.test.ts
+++ b/packages/jellyfish-json/__tests__/index.test.ts
@@ -66,7 +66,7 @@ describe('stringify', () => {
   })
   it('should stringify bigint as json number', () => {
     const string = JellyfishJSON.stringify({
-      bigint: new BigInt('120000000000000001')
+      bigint: BigInt('120000000000000001')
     })
     expect(string).toStrictEqual('{"bigint":120000000000000001}')
   })

--- a/packages/jellyfish-json/__tests__/index.test.ts
+++ b/packages/jellyfish-json/__tests__/index.test.ts
@@ -64,6 +64,12 @@ describe('stringify', () => {
     })
     expect(string).toStrictEqual('{"bignumber":1200000000.00000001}')
   })
+  it('should stringify bigint as json number', () => {
+    const string = JellyfishJSON.stringify({
+      bigint: new BigInt('120000000000000001')
+    })
+    expect(string).toStrictEqual('{"bigint":120000000000000001n}')
+  })
 })
 
 it('should remap object at root with precision', () => {

--- a/packages/jellyfish-json/src/index.ts
+++ b/packages/jellyfish-json/src/index.ts
@@ -71,6 +71,9 @@ export const JellyfishJSON = {
       if (value instanceof BigNumber) {
         return new LosslessNumber(value.toString())
       }
+      if (typeof value === "bigint") {
+        return new LosslessNumber(value.toString())
+      }
       return value
     }
 

--- a/packages/jellyfish-json/src/index.ts
+++ b/packages/jellyfish-json/src/index.ts
@@ -71,7 +71,7 @@ export const JellyfishJSON = {
       if (value instanceof BigNumber) {
         return new LosslessNumber(value.toString())
       }
-      if (typeof value === "bigint") {
+      if (typeof value === 'bigint') {
         return new LosslessNumber(value.toString())
       }
       return value


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

`bigint` is still not supported. using `stringify()` on a bigint will result in `undefined`.

#### Which issue(s) does this PR fixes?:


#### Additional comments?:
