### PR TITLE
feat(jellyfish-wallet-encrypted, jellyfish-wallet-mnemonic): add public key uncompressed

### DIFF
--- a/packages/jellyfish-crypto/src/eth.ts
+++ b/packages/jellyfish-crypto/src/eth.ts
@@ -33,7 +33,7 @@ export const Eth = {
       throw new Error('InvalidUncompressedPubKeyLength')
     }
     const sub = pubKeyUncompressed.subarray(1, 65)
-    const hash = KECCAK256(sub)
+    const hash = KECCAK256(Buffer.from(sub))
     return toChecksumAddress(toAddress(hash))
   }
 }

--- a/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
+++ b/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
@@ -171,6 +171,11 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
       await expect(promise).rejects.toThrowError('Missing private key for hardened child key')
     })
 
+    it('should not derive pub key uncompressed because hardened', async () => {
+      const promise = node.publicKey()
+      await expect(promise).rejects.toThrowError('Missing private key for hardened child key')
+    })
+
     it('should derive priv key', async () => {
       const privKey = await node.privateKey()
       expect(privKey.toString('hex')).toStrictEqual('b5b25c4628c5bb31a673ee8d1ab4c378ae50df2b173cf99d26cfe7848d834628')
@@ -199,7 +204,7 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
       await expect(promise).rejects.toThrowError('Missing private key for hardened child key')
     })
 
-    it('should derive pub key uncompressed', async () => {
+    it('should not derive pub key uncompressed', async () => {
       const promise = node.publicKeyUncompressed()
       await expect(promise).rejects.toThrowError('Missing private key for hardened child key')
     })

--- a/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
+++ b/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
@@ -166,12 +166,6 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
       await expect(promise).rejects.toThrowError('Missing private key for hardened child key')
     })
 
-    it('should derive pub key uncompressed', async () => {
-      const pubKeyUncompressed = '044849fafd49b531a2b8a101993c34ea5c70bdc094fd4fc45d2fca2068d2143553e34595e90fe1f08ecab8cfa94d6eb8a46ece4a41856b090be147f1243def0397'
-      const derivedPubKeyUncompressed = await node.publicKeyUncompressed()
-      expect(derivedPubKeyUncompressed.toString('hex')).toStrictEqual(pubKeyUncompressed)
-    })
-
     it('should derive priv key', async () => {
       const privKey = await node.privateKey()
       expect(privKey.toString('hex')).toStrictEqual('b5b25c4628c5bb31a673ee8d1ab4c378ae50df2b173cf99d26cfe7848d834628')
@@ -197,6 +191,11 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
 
     it('should derive pub key', async () => {
       const promise = node.publicKey()
+      await expect(promise).rejects.toThrowError('Missing private key for hardened child key')
+    })
+
+    it('should derive pub key uncompressed', async () => {
+      const promise = node.publicKeyUncompressed()
       await expect(promise).rejects.toThrowError('Missing private key for hardened child key')
     })
 

--- a/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
+++ b/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
@@ -101,6 +101,11 @@ describe('24 words: random with passphrase "random" (exact same test in jellyfis
       expect(derivedPubKey.length).toStrictEqual(33)
     })
 
+    it('should derive pub key uncompressed', async () => {
+      const derivedPubKeyUncompressed = await node.publicKeyUncompressed()
+      expect(derivedPubKeyUncompressed.length).toStrictEqual(65)
+    })
+
     it('should derive priv key', async () => {
       const derivedPrivKey = await node.privateKey()
       expect(derivedPrivKey.length).toStrictEqual(32)
@@ -227,6 +232,11 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
       expect(derivedPubKey.toString('hex')).toStrictEqual('0357e2eb9dee0792a24c7a9047bd05e28acd7a9275bc2b33916b1e434993f5db96')
     })
 
+    it('should derive pub key uncompressed', async () => {
+      const derivedPubKey = await node.publicKeyUncompressed()
+      expect(derivedPubKey.toString('hex')).toStrictEqual('0457e2eb9dee0792a24c7a9047bd05e28acd7a9275bc2b33916b1e434993f5db967f9c7f228e5a015fbd7d1c1bd744af6099ec3ffc37815cf982c5a70dd438ba63')
+    })
+
     it('should derive priv key', async () => {
       const privKey = await node.privateKey()
       expect(privKey.toString('hex')).toStrictEqual('c168700046e2cdfab52f5da5d5975ecaaaffa45c5b174100a0dab260a252cd43')
@@ -271,6 +281,11 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
     it('should derive pub key', async () => {
       const derivedPubKey = await node.publicKey()
       expect(derivedPubKey.toString('hex')).toStrictEqual('02dc83dda8b4e068d45fe63eaa12f2abbe4391569ffd25b031229275f9eb1f2efd')
+    })
+
+    it('should derive pub key uncompressed', async () => {
+      const derivedPubKey = await node.publicKeyUncompressed()
+      expect(derivedPubKey.toString('hex')).toStrictEqual('04dc83dda8b4e068d45fe63eaa12f2abbe4391569ffd25b031229275f9eb1f2efd3fce4ab6ff5a0903f2304e0772e2cc3ed1779e1d61ae6a08416ca0f425fba51e')
     })
 
     it('should derive priv key', async () => {

--- a/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
+++ b/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
@@ -166,6 +166,12 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
       await expect(promise).rejects.toThrowError('Missing private key for hardened child key')
     })
 
+    it('should derive pub key uncompressed', async () => {
+      const pubKeyUncompressed = '044849fafd49b531a2b8a101993c34ea5c70bdc094fd4fc45d2fca2068d2143553e34595e90fe1f08ecab8cfa94d6eb8a46ece4a41856b090be147f1243def0397'
+      const derivedPubKeyUncompressed = await node.publicKeyUncompressed()
+      expect(derivedPubKeyUncompressed.toString('hex')).toStrictEqual(pubKeyUncompressed)
+    })
+
     it('should derive priv key', async () => {
       const privKey = await node.privateKey()
       expect(privKey.toString('hex')).toStrictEqual('b5b25c4628c5bb31a673ee8d1ab4c378ae50df2b173cf99d26cfe7848d834628')

--- a/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
+++ b/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
@@ -72,6 +72,11 @@ describe('24 words: random with passphrase "random" (exact same test in jellyfis
       await expect(promise).rejects.toThrowError('Missing private key for hardened child key')
     })
 
+    it('should not derive pub key uncompressed because hardened', async () => {
+      const promise = node.publicKey()
+      await expect(promise).rejects.toThrowError('Missing private key for hardened child key')
+    })
+
     it('should derive priv key', async () => {
       const derivedPrivKey = await node.privateKey()
       expect(derivedPrivKey.length).toStrictEqual(32)
@@ -199,7 +204,7 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
       node = provider.derive("44'/1129'/1'/0/0")
     })
 
-    it('should derive pub key', async () => {
+    it('should not derive pub key', async () => {
       const promise = node.publicKey()
       await expect(promise).rejects.toThrowError('Missing private key for hardened child key')
     })

--- a/packages/jellyfish-wallet-encrypted/src/hd_node.ts
+++ b/packages/jellyfish-wallet-encrypted/src/hd_node.ts
@@ -1,4 +1,5 @@
 import { WalletHdNodeProvider } from '@defichain/jellyfish-wallet'
+import { pointCompress } from 'tiny-secp256k1'
 import * as bip32 from 'bip32'
 import { Bip32Options, MnemonicHdNode, MnemonicHdNodeProvider } from '@defichain/jellyfish-wallet-mnemonic'
 import { PrivateKeyEncryption } from './encryption'
@@ -39,6 +40,14 @@ export class EncryptedMnemonicHdNode extends MnemonicHdNode {
     return bip32.fromPublicKey(this.rootPubKey, this.chainCode, this.options)
       .derivePath(this.path)
       .publicKey
+  }
+
+  /**
+   * @return Promise<Buffer> uncompressed public key
+   */
+  async publicKeyUncompressed (): Promise<Buffer> {
+    const publicKey = await this.publicKey()
+    return Buffer.from(pointCompress(publicKey, false))
   }
 }
 

--- a/packages/jellyfish-wallet-mnemonic/src/hd_node.ts
+++ b/packages/jellyfish-wallet-mnemonic/src/hd_node.ts
@@ -58,8 +58,8 @@ export class MnemonicHdNode implements WalletHdNode {
    * @return Promise<Buffer> uncompressed public key
    */
   async publicKeyUncompressed (): Promise<Buffer> {
-    const node = await this.deriveNode()
-    return Buffer.from(pointCompress(node.publicKey, false))
+    const publicKey = await this.publicKey()
+    return Buffer.from(pointCompress(publicKey, false))
   }
 
   /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Need uncompressed public key for encrypted wallets to be able to getEvmAddress
- Need to be able to get uncompressed public key without needing the privateKey (getDerivedNode) because it would require passphrase prompt just to fetch evm address

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes DFC-178, DFC-182

#### Additional comments?:
