### PR TITLE
fix(jellyfish-crypto): explicitly convert uncompressed sub array into buffer

### DIFF
--- a/packages/jellyfish-crypto/src/eth.ts
+++ b/packages/jellyfish-crypto/src/eth.ts
@@ -33,7 +33,7 @@ export const Eth = {
       throw new Error('InvalidUncompressedPubKeyLength')
     }
     const sub = pubKeyUncompressed.subarray(1, 65)
-    const hash = KECCAK256(sub)
+    const hash = KECCAK256(Buffer.from(sub))
     return toChecksumAddress(toAddress(hash))
   }
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
For some reason on other application builds (like LW), Keccak is throwing an error about the data type.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes DFC-182

#### Additional comments?:
