### PR TITLE
Fix(apps/whale-api): rm error before index

### DIFF
--- a/apps/whale-api/src/module.indexer/model/dftx/composite.swap.ts
+++ b/apps/whale-api/src/module.indexer/model/dftx/composite.swap.ts
@@ -4,7 +4,6 @@ import { RawBlock } from '../_abstract'
 import { Inject, Injectable } from '@nestjs/common'
 import { NetworkName } from '@defichain/jellyfish-network'
 import BigNumber from 'bignumber.js'
-import { IndexerError } from '../../error'
 import { PoolPairPathMapping } from './pool.pair.path.mapping'
 import { PoolSwapIndexer } from './pool.swap'
 
@@ -51,10 +50,10 @@ export class CompositeSwapIndexer extends DfTxIndexer<CompositeSwap> {
 
     const poolSwap = compositeSwap.poolSwap
     const pair = await this.poolPairPathMapping.findPair(poolSwap.fromTokenId, poolSwap.toTokenId)
-    if (pair !== undefined) {
-      return [{ id: Number(pair.id) }]
+    while (true) {
+      if (pair !== undefined) {
+        return [{ id: Number(pair.id) }]
+      }
     }
-
-    throw new IndexerError(`Pool for pair ${poolSwap.fromTokenId}, ${poolSwap.toTokenId} not found in PoolPairPathMapping`)
   }
 }

--- a/apps/whale-api/src/module.indexer/model/dftx/pool.swap.ts
+++ b/apps/whale-api/src/module.indexer/model/dftx/pool.swap.ts
@@ -9,7 +9,6 @@ import { HexEncoder } from '../../../module.model/_hex.encoder'
 import { PoolSwapAggregatedMapper } from '../../../module.model/pool.swap.aggregated'
 import { AggregatedIntervals } from './pool.swap.aggregated'
 import { PoolPairInfoWithId } from '../../../module.api/cache/defid.cache'
-import { IndexerError } from '../../error'
 import { PoolPairPathMapping } from './pool.pair.path.mapping'
 
 @Injectable()
@@ -89,11 +88,11 @@ export class PoolSwapIndexer extends DfTxIndexer<PoolSwap> {
   }
 
   async getPair (tokenA: number, tokenB: number): Promise<PoolPairInfoWithId> {
-    const pair = await this.poolPairPathMapping.findPair(tokenA, tokenB)
-    if (pair !== undefined) {
-      return pair
+    while (true) {
+      const pair = await this.poolPairPathMapping.findPair(tokenA, tokenB)
+      if (pair !== undefined) {
+        return pair
+      }
     }
-
-    throw new IndexerError(`Pool for pair ${tokenA}, ${tokenB} not found in PoolPairPathMapping`)
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- should not throw error before index as err will trigger cleanup to invalidate non-existent data
- ensure poolpair.pathing caches the latest

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
