### PR TITLE
feat(jellyfish-address, jellyfish-wallet): add eth.fromScript

### DIFF
--- a/packages/jellyfish-address/__tests__/eth.test.ts
+++ b/packages/jellyfish-address/__tests__/eth.test.ts
@@ -1,4 +1,4 @@
-import { OP_CODES } from '@defichain/jellyfish-transaction'
+import { OP_CODES, Script } from '@defichain/jellyfish-transaction'
 import { Eth } from '../src'
 
 const keypair = {
@@ -20,4 +20,26 @@ it('should convert evm address to script', () => {
 it('should return undefined script for invalid eth address', () => {
   const evmScript = Eth.fromAddress('0xabc123')
   expect(evmScript).toStrictEqual(undefined)
+})
+
+it('should convert evm script to address', () => {
+  const script: Script = {
+    stack: [
+      OP_CODES.OP_16,
+      OP_CODES.OP_PUSHDATA_HEX_BE(keypair.evmAddr.substring(2))
+    ]
+  }
+  const evmAddress = Eth.fromScript(script)
+  expect(evmAddress).toStrictEqual(keypair.evmAddr.substring(2))
+})
+
+it('should return undefined address for invalid evm script', () => {
+  const script: Script = {
+    stack: [
+      OP_CODES.OP_0,
+      OP_CODES.OP_PUSHDATA_HEX_BE(keypair.evmAddr.substring(2))
+    ]
+  }
+  const evmAddress = Eth.fromScript(script)
+  expect(evmAddress).toStrictEqual(undefined)
 })

--- a/packages/jellyfish-address/__tests__/eth.test.ts
+++ b/packages/jellyfish-address/__tests__/eth.test.ts
@@ -12,7 +12,7 @@ it('should convert evm address to script', () => {
   expect(evmScript).toStrictEqual({
     stack: [
       OP_CODES.OP_16,
-      OP_CODES.OP_PUSHDATA_HEX_LE(keypair.evmAddr.substring(2))
+      OP_CODES.OP_PUSHDATA_HEX_BE(keypair.evmAddr.substring(2))
     ]
   })
 })

--- a/packages/jellyfish-address/src/eth.ts
+++ b/packages/jellyfish-address/src/eth.ts
@@ -1,9 +1,15 @@
-import { OP_CODES, Script } from '@defichain/jellyfish-transaction'
+import { OP_CODES, OP_PUSHDATA, Script } from '@defichain/jellyfish-transaction'
 
 function validateAddress (address: string): boolean {
   // https://github.com/ethers-io/ethers.js/blob/5210b68a7837654c6b84207a45e1e573d9472d1a/src.ts/address/address.ts#L123
   const regex: RegExp = /^0x[a-fA-F0-9]{40}$/gm
   return regex.test(address)
+}
+
+function validateScript (script: Script): boolean {
+  return script.stack.length === 2 &&
+    script.stack[0].type === OP_CODES.OP_16.type &&
+    script.stack[1].type === 'OP_PUSHDATA' && (script.stack[1] as OP_PUSHDATA).length() === 20
 }
 
 export const Eth = {
@@ -21,5 +27,19 @@ export const Eth = {
         OP_CODES.OP_PUSHDATA_HEX_BE(address.substring(2))
       ]
     }
+  },
+
+  /**
+   * EVM Script is LE in DVM, revert back to BE as what Ethereum behave
+   *
+   * @param {Script} script to convert into address
+   * @returns {string} address parsed from script
+   */
+  fromScript (script: Script): string | undefined {
+    if (!validateScript(script)) {
+      return undefined
+    }
+    const { hex } = (script.stack[1] as OP_PUSHDATA)
+    return Buffer.from(hex, 'hex').reverse().toString('hex')
   }
 }

--- a/packages/jellyfish-address/src/eth.ts
+++ b/packages/jellyfish-address/src/eth.ts
@@ -18,7 +18,7 @@ export const Eth = {
     return {
       stack: [
         OP_CODES.OP_16,
-        OP_CODES.OP_PUSHDATA_HEX_LE(address.substring(2))
+        OP_CODES.OP_PUSHDATA_HEX_BE(address.substring(2))
       ]
     }
   }

--- a/packages/jellyfish-transaction-builder/__tests__/provider.mock.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/provider.mock.ts
@@ -4,7 +4,7 @@ import { EllipticPairProvider, FeeRateProvider, Prevout, PrevoutProvider } from 
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { OP_CODES, Script } from '@defichain/jellyfish-transaction'
 import { randomEllipticPair } from './test.utils'
-import { ListUnspentQueryOptions } from '@defichain/jellyfish-api-core/dist/category/wallet'
+import { ListUnspentQueryOptions } from '@defichain/jellyfish-api-core/src/category/wallet'
 
 export class MockFeeRateProvider implements FeeRateProvider {
   constructor (

--- a/packages/jellyfish-transaction-builder/src/provider.ts
+++ b/packages/jellyfish-transaction-builder/src/provider.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { EllipticPair } from '@defichain/jellyfish-crypto'
 import { Vout } from '@defichain/jellyfish-transaction'
-import { ListUnspentQueryOptions } from '@defichain/jellyfish-api-core/dist/category/wallet'
+import { ListUnspentQueryOptions } from '@defichain/jellyfish-api-core/src/category/wallet'
 
 export interface FeeRateProvider {
   /**

--- a/packages/jellyfish-transaction-builder/src/txn/txn_builder.ts
+++ b/packages/jellyfish-transaction-builder/src/txn/txn_builder.ts
@@ -15,7 +15,7 @@ import { calculateFeeP2WPKH } from './txn_fee'
 import { TxnBuilderError, TxnBuilderErrorType } from './txn_builder_error'
 import { EllipticPair } from '@defichain/jellyfish-crypto'
 import { Network } from '@defichain/jellyfish-network'
-import { ListUnspentQueryOptions } from '@defichain/jellyfish-api-core/dist/category/wallet'
+import { ListUnspentQueryOptions } from '@defichain/jellyfish-api-core/src/category/wallet'
 
 const MAX_FEE_RATE = new BigNumber('0.00100000')
 

--- a/packages/jellyfish-transaction-builder/src/txn/txn_builder_account.ts
+++ b/packages/jellyfish-transaction-builder/src/txn/txn_builder_account.ts
@@ -5,7 +5,7 @@ import {
 } from '@defichain/jellyfish-transaction'
 import { P2WPKHTxnBuilder } from './txn_builder'
 import { TxnBuilderError, TxnBuilderErrorType } from './txn_builder_error'
-import { ListUnspentQueryOptions } from '@defichain/jellyfish-api-core/dist/category/wallet'
+import { ListUnspentQueryOptions } from '@defichain/jellyfish-api-core/src/category/wallet'
 
 export class TxnBuilderAccount extends P2WPKHTxnBuilder {
   /**

--- a/packages/jellyfish-wallet/src/wallet_account.ts
+++ b/packages/jellyfish-wallet/src/wallet_account.ts
@@ -55,7 +55,7 @@ export abstract class WalletAccount implements WalletEllipticPair {
     return {
       stack: [
         OP_CODES.OP_16,
-        OP_CODES.OP_PUSHDATA_HEX_LE(Eth.fromPubKeyUncompressed(pubKeyUncompressed).substring(2))
+        OP_CODES.OP_PUSHDATA_HEX_BE(Eth.fromPubKeyUncompressed(pubKeyUncompressed).substring(2))
       ]
     }
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

add `eth.fromScript(evmScript) -> evmAddr` and "PR pool" some fixes

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
- [x] use `src` on import  [e63af92](https://github.com/BirthdayResearch/jellyfishsdk/pull/2157/commits/e63af920d88902cba54cd345fb50f4df3b932561)
- [x] fix missing eth BE [291fd1f](https://github.com/BirthdayResearch/jellyfishsdk/pull/2157/commits/291fd1faf0543a21f94b36b259d773c79fdb0fa1)
- [x] add eth.fromScript [35aa1e5](https://github.com/BirthdayResearch/jellyfishsdk/pull/2157/commits/35aa1e549a139f7c04eb2d3a3c8479b645c4b429)

#### Additional comments?:
