### PR TITLE
fix(whale-api-client): new default url

### DIFF
--- a/packages/ocean-api-client/src/OceanApiClient.ts
+++ b/packages/ocean-api-client/src/OceanApiClient.ts
@@ -2,6 +2,7 @@ import 'url-search-params-polyfill'
 import AbortController from 'abort-controller'
 import fetch from 'cross-fetch'
 import { ApiException, ApiMethod, ApiPagedResponse, ApiResponse, ClientException, TimeoutException } from './'
+import { NetworkName } from '@defichain/jellyfish-network'
 
 /**
  * OceanApiClient configurable options
@@ -24,7 +25,19 @@ export interface OceanApiClientOptions {
   /**
    * Network that ocean client is configured to
    */
-  network?: 'mainnet' | 'testnet' | 'devnet' | 'regtest' | 'changi' | string
+  network?: NetworkName | 'playground'
+}
+
+/**
+ * OceanApiClient default options
+ */
+function getDefaultOptions (network: NetworkName | 'playground'): OceanApiClientOptions {
+  return {
+    url: `https://${network}.ocean.jellyfishsdk.com`,
+    timeout: 60000,
+    version: 'v0',
+    network
+  }
 }
 
 /**
@@ -35,10 +48,7 @@ export class OceanApiClient {
     protected readonly options: OceanApiClientOptions
   ) {
     this.options = {
-      url: 'https://ocean.defichain.com',
-      timeout: 60000,
-      version: 'v1',
-      network: 'mainnet',
+      ...getDefaultOptions(options?.network ?? 'mainnet'),
       ...options
     }
     this.options.url = this.options.url?.replace(/\/$/, '')

--- a/packages/whale-api-client/__tests__/WhaleApiClient.test.ts
+++ b/packages/whale-api-client/__tests__/WhaleApiClient.test.ts
@@ -1,42 +1,58 @@
 import nock from 'nock'
 import { WhaleApiClient } from '@defichain/whale-api-client/dist/whale.api.client'
+import { NetworkName } from '@defichain/jellyfish-network'
 
-const client = new WhaleApiClient({
-  url: 'http://whale-api-test.internal',
-  network: 'regtest',
-  version: 'v0.0'
+describe('WhaleApiClient default url', () => {
+  it.each<NetworkName>([
+    'mainnet',
+    'testnet'
+  ])('should query default url successfully: %s', async (network: NetworkName) => {
+    const client = new WhaleApiClient({ network })
+    const response = await client.stats.get()
+    expect(response).toMatchObject({
+      blockchain: expect.any(Object)
+    })
+  })
 })
 
-it('should requestData via GET', async () => {
-  nock('http://whale-api-test.internal')
-    .get('/v0.0/regtest/foo')
-    .reply(200, function () {
-      return {
-        data: {
-          bar: ['1', '2']
+describe('WhaleApiClient HTTP', () => {
+  const client = new WhaleApiClient({
+    url: 'http://whale-api-test.internal',
+    network: 'regtest',
+    version: 'v0.0'
+  })
+
+  it('should requestData via GET', async () => {
+    nock('http://whale-api-test.internal')
+      .get('/v0.0/regtest/foo')
+      .reply(200, function () {
+        return {
+          data: {
+            bar: ['1', '2']
+          }
         }
-      }
+      })
+
+    const result = await client.requestData('GET', 'foo')
+    await expect(result).toStrictEqual({
+      bar: ['1', '2']
     })
-
-  const result = await client.requestData('GET', 'foo')
-  await expect(result).toStrictEqual({
-    bar: ['1', '2']
   })
-})
 
-it('should requestData via POST', async () => {
-  nock('http://whale-api-test.internal')
-    .post('/v0.0/regtest/bar')
-    .reply(200, function (_, body: object) {
-      return {
-        data: body
-      }
+  it('should requestData via POST', async () => {
+    nock('http://whale-api-test.internal')
+      .post('/v0.0/regtest/bar')
+      .reply(200, function (_, body: object) {
+        return {
+          data: body
+        }
+      })
+
+    const result = await client.requestData('POST', 'bar', {
+      abc: ['a', 'b', 'c']
     })
-
-  const result = await client.requestData('POST', 'bar', {
-    abc: ['a', 'b', 'c']
-  })
-  await expect(result).toStrictEqual({
-    abc: ['a', 'b', 'c']
+    await expect(result).toStrictEqual({
+      abc: ['a', 'b', 'c']
+    })
   })
 })

--- a/packages/whale-api-client/src/whale.api.client.ts
+++ b/packages/whale-api-client/src/whale.api.client.ts
@@ -47,11 +47,13 @@ export interface WhaleApiClientOptions {
 /**
  * WhaleApiClient default options
  */
-const DEFAULT_OPTIONS: WhaleApiClientOptions = {
-  url: 'https://ocean.defichain.com',
-  timeout: 60000,
-  version: 'v0',
-  network: 'mainnet'
+function getDefaultOptions (network: NetworkName): WhaleApiClientOptions {
+  return {
+    url: `https://${network}.ocean.jellyfishsdk.com`,
+    timeout: 60000,
+    version: 'v0',
+    network
+  }
 }
 
 /**
@@ -88,7 +90,10 @@ export class WhaleApiClient {
   constructor (
     protected readonly options: WhaleApiClientOptions
   ) {
-    this.options = { ...DEFAULT_OPTIONS, ...options }
+    this.options = {
+      ...getDefaultOptions(options?.network ?? 'mainnet'),
+      ...options
+    }
     this.options.url = this.options.url?.replace(/\/$/, '')
   }
 


### PR DESCRIPTION
#### What this PR does / why we need it:
- Updates the default URLs to point to `<network>.ocean.jellyfishsdk.com`
- Adds the necessary test